### PR TITLE
feat: add live metrics dashboard example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ settings.
 }
 ```
 
+> **Note:** The request body must include the `content` field shown above. Older
+> snippets or third-party examples that send a `message` property will be
+> rejected by FastAPI's validation layer with a `content: field required`
+> error. Update any clients to provide `content` to avoid HTTP 422 responses.
+
 ```json
 {
   "session_id": "<uuid>",
@@ -174,6 +179,11 @@ python examples/basic_session.py
 The script reads the `CHAT_API_URL`, `CHAT_PROVIDER`, and `CHAT_USER_MESSAGE`
 environment variables so you can target remote deployments or experiment with
 different providers and prompts.
+
+For a visual look at the service health, open `examples/metrics.html` in a
+browser while the API is running locally. The page uses the Vazir font, polls
+`GET /metrics` on a configurable interval (۲۰ ثانیه به طور پیش‌فرض), and plots
+live charts for total requests, responses, and errors.
 
 ## Development notes
 - The default memory backend is in-process. Setting `REDIS_URL` enables the

--- a/examples/admin_ui.html
+++ b/examples/admin_ui.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>پنل مدیریت Rate Limit</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/vazir-font@30.1.0/dist/font-face.css"
+    />
     <style>
       :root {
         color-scheme: light dark;
@@ -14,7 +18,7 @@
         --accent: #42c3ff;
         --text: #f5f7fb;
         font-size: 16px;
-        font-family: "IRANSans", "Vazirmatn", "Segoe UI", sans-serif;
+        font-family: "Vazir", "IRANSans", "Vazirmatn", "Segoe UI", sans-serif;
       }
 
       * {

--- a/examples/chat.html
+++ b/examples/chat.html
@@ -377,14 +377,14 @@
       });
     }
 
-    async function sendMessage(message) {
+    async function sendMessage(content) {
       if (!sessionId) {
         alert('ابتدا سشن بساز.');
         return;
       }
       const baseUrl = baseUrlInput.value.trim();
 
-      appendMessage({ role: 'user', content: message, provider: 'you', timestamp: new Date() });
+      appendMessage({ role: 'user', content, provider: 'you', timestamp: new Date() });
       setLoading(true, 'در انتظار پاسخ سرور');
 
       try {
@@ -392,7 +392,7 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            message,
+            content,
             provider: providerInput.value.trim() || undefined,
             fallback_provider: fallbackInput.value.trim() || undefined
           })
@@ -400,8 +400,11 @@
 
         const data = await response.json();
         if (!response.ok) {
-          const message = data?.error || 'پاسخ نامعتبر';
-          throw new Error(message);
+          const errorMessage =
+            typeof data?.error === 'string'
+              ? data.error
+              : data?.error?.message || 'پاسخ نامعتبر';
+          throw new Error(errorMessage);
         }
 
         appendMessage({

--- a/examples/metrics.html
+++ b/examples/metrics.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>نمودار زنده متریک‌ها</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/vazir-font@30.1.0/dist/font-face.css"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Vazir", "Vazirmatn", "IRANSans", "Segoe UI", sans-serif;
+        font-size: 16px;
+        --bg: #0f172a;
+        --card: rgba(15, 23, 42, 0.8);
+        --accent: #38bdf8;
+        --text: #e2e8f0;
+        --muted: #94a3b8;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2.5rem 1.5rem;
+        color: var(--text);
+      }
+
+      .container {
+        width: min(1080px, 100%);
+        background: var(--card);
+        border-radius: 28px;
+        box-shadow: 0 35px 70px rgba(8, 11, 24, 0.45);
+        padding: 2.5rem 3rem;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        backdrop-filter: blur(18px);
+      }
+
+      header {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 2rem;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: 2.2rem;
+        letter-spacing: -0.6px;
+      }
+
+      .controls {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      label {
+        font-weight: 600;
+        color: var(--muted);
+      }
+
+      select {
+        padding: 0.65rem 1.2rem;
+        border-radius: 16px;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: rgba(15, 23, 42, 0.6);
+        color: var(--text);
+        font-size: 1rem;
+        cursor: pointer;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      select:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+      }
+
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1.25rem;
+        margin-bottom: 2rem;
+      }
+
+      .stat-card {
+        background: rgba(15, 23, 42, 0.6);
+        border-radius: 20px;
+        padding: 1.5rem;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      .stat-card h2 {
+        margin: 0 0 0.6rem;
+        font-size: 1.05rem;
+        color: var(--muted);
+      }
+
+      .stat-card p {
+        margin: 0;
+        font-size: 1.5rem;
+        font-weight: 700;
+        letter-spacing: 0.4px;
+      }
+
+      .chart-wrapper {
+        position: relative;
+        width: 100%;
+        height: 420px;
+      }
+
+      footer {
+        margin-top: 2rem;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 1rem;
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+
+      .error {
+        color: #f87171;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <div>
+          <h1>نمای زنده متریک‌های سرویس</h1>
+          <p>داده‌های به‌دست‌آمده از <code>GET /metrics</code></p>
+        </div>
+        <div class="controls">
+          <label for="interval">بازهٔ به‌روزرسانی</label>
+          <select id="interval">
+            <option value="5000">۵ ثانیه</option>
+            <option value="10000">۱۰ ثانیه</option>
+            <option value="20000" selected>۲۰ ثانیه</option>
+            <option value="30000">۳۰ ثانیه</option>
+            <option value="60000">۶۰ ثانیه</option>
+          </select>
+        </div>
+      </header>
+
+      <section class="stats" aria-live="polite">
+        <div class="stat-card">
+          <h2>تعداد کل درخواست‌ها</h2>
+          <p id="requestsTotal">۰</p>
+        </div>
+        <div class="stat-card">
+          <h2>تعداد کل پاسخ‌ها</h2>
+          <p id="responsesTotal">۰</p>
+        </div>
+        <div class="stat-card">
+          <h2>تعداد خطاها</h2>
+          <p id="errorsTotal">۰</p>
+        </div>
+        <div class="stat-card">
+          <h2>میانگین تأخیر (میلی‌ثانیه)</h2>
+          <p id="latencyAvg">۰</p>
+        </div>
+      </section>
+
+      <div class="chart-wrapper">
+        <canvas id="metricsChart" aria-label="نمودار روند درخواست‌ها" role="img"></canvas>
+      </div>
+
+      <footer>
+        <div>آخرین به‌روزرسانی: <span id="lastUpdated">—</span></div>
+        <div id="status"></div>
+      </footer>
+    </div>
+
+    <script>
+      const chartElement = document.getElementById("metricsChart");
+      const statusEl = document.getElementById("status");
+      const lastUpdatedEl = document.getElementById("lastUpdated");
+      const intervalSelect = document.getElementById("interval");
+
+      const requestsTotalEl = document.getElementById("requestsTotal");
+      const responsesTotalEl = document.getElementById("responsesTotal");
+      const errorsTotalEl = document.getElementById("errorsTotal");
+      const latencyAvgEl = document.getElementById("latencyAvg");
+
+      const dataConfig = {
+        labels: [],
+        datasets: [
+          {
+            label: "درخواست‌ها",
+            data: [],
+            borderColor: "#38bdf8",
+            backgroundColor: "rgba(56, 189, 248, 0.15)",
+            tension: 0.35,
+            fill: true,
+          },
+          {
+            label: "پاسخ‌ها",
+            data: [],
+            borderColor: "#34d399",
+            backgroundColor: "rgba(52, 211, 153, 0.15)",
+            tension: 0.35,
+            fill: true,
+          },
+          {
+            label: "خطاها",
+            data: [],
+            borderColor: "#f87171",
+            backgroundColor: "rgba(248, 113, 113, 0.15)",
+            tension: 0.35,
+            fill: true,
+          },
+        ],
+      };
+
+      const chart = new Chart(chartElement, {
+        type: "line",
+        data: dataConfig,
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: {
+            mode: "index",
+            intersect: false,
+          },
+          plugins: {
+            legend: {
+              labels: {
+                font: {
+                  family: "Vazir",
+                },
+              },
+            },
+            tooltip: {
+              callbacks: {
+                label: (context) => {
+                  const label = context.dataset.label || "";
+                  const value = context.parsed.y ?? 0;
+                  return `${label}: ${value.toLocaleString("fa-IR")}`;
+                },
+              },
+              bodyFont: {
+                family: "Vazir",
+              },
+              titleFont: {
+                family: "Vazir",
+              },
+            },
+          },
+          scales: {
+            x: {
+              ticks: {
+                font: {
+                  family: "Vazir",
+                },
+              },
+            },
+            y: {
+              beginAtZero: true,
+              ticks: {
+                precision: 0,
+                font: {
+                  family: "Vazir",
+                },
+              },
+            },
+          },
+        },
+      });
+
+      let timerId;
+
+      async function fetchMetrics() {
+        try {
+          statusEl.textContent = "";
+          const response = await fetch("http://localhost:8000/metrics", {
+            headers: { Accept: "application/json" },
+          });
+
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+
+          const payload = await response.json();
+          updateStats(payload);
+          appendChartPoint(payload);
+          lastUpdatedEl.textContent = new Date().toLocaleTimeString("fa-IR");
+        } catch (error) {
+          console.error(error);
+          statusEl.innerHTML = `<span class="error">خطا در دریافت متریک‌ها: ${error.message}</span>`;
+        }
+      }
+
+      function updateStats(metrics) {
+        const {
+          requests_total = 0,
+          responses_total = 0,
+          errors_total = 0,
+          request_latency_avg_ms = 0,
+        } = metrics;
+
+        requestsTotalEl.textContent = requests_total.toLocaleString("fa-IR");
+        responsesTotalEl.textContent = responses_total.toLocaleString("fa-IR");
+        errorsTotalEl.textContent = errors_total.toLocaleString("fa-IR");
+        latencyAvgEl.textContent = request_latency_avg_ms.toLocaleString("fa-IR", {
+          maximumFractionDigits: 2,
+        });
+      }
+
+      function appendChartPoint(metrics) {
+        const timestamp = new Date().toLocaleTimeString("fa-IR");
+        dataConfig.labels.push(timestamp);
+        dataConfig.datasets[0].data.push(metrics.requests_total ?? 0);
+        dataConfig.datasets[1].data.push(metrics.responses_total ?? 0);
+        dataConfig.datasets[2].data.push(metrics.errors_total ?? 0);
+
+        const maxPoints = 30;
+        if (dataConfig.labels.length > maxPoints) {
+          dataConfig.labels.shift();
+          dataConfig.datasets.forEach((dataset) => dataset.data.shift());
+        }
+
+        chart.update();
+      }
+
+      function scheduleNextFetch() {
+        clearTimeout(timerId);
+        timerId = setTimeout(async () => {
+          await fetchMetrics();
+          scheduleNextFetch();
+        }, Number(intervalSelect.value));
+      }
+
+      intervalSelect.addEventListener("change", () => {
+        scheduleNextFetch();
+      });
+
+      fetchMetrics().then(scheduleNextFetch);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a metrics dashboard example that uses the Vazir font and polls GET /metrics
- visualize request, response, and error counters with a live Chart.js line chart
- document the dashboard in the README examples section with configurable refresh interval details

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e41c3555d083259d7de4afc703dba0