### PR TITLE
Default MCP agent to OpenRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ ADMIN_TOKEN=change-me
 
 # Provider credentials
 OPENAI_API_KEY=
+OPENROUTER_KEY=
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_MODEL=openrouter/auto
 MCP_SERVER_URL=
 MCP_API_KEY=
 # Path to an mcp_agent.config.yaml file that declares MCP servers
@@ -15,7 +18,7 @@ MCP_AGENT_SERVERS=
 # Optional overrides for the embedded MCP agent
 MCP_AGENT_APP_NAME=chat-backend
 MCP_AGENT_INSTRUCTION=
-MCP_AGENT_LLM=openai
+MCP_AGENT_LLM=openrouter
 MCP_AGENT_MODEL=
 
 # Persistence

--- a/README.md
+++ b/README.md
@@ -64,8 +64,13 @@ mcp:
 ```
 
 Set `MCP_AGENT_SERVERS=filesystem,fetch` (or any other two entries defined in
-the configuration file) and supply an `OPENAI_API_KEY` so the built-in
-`OpenAIAugmentedLLM` can coordinate the tools.
+the configuration file) and choose the LLM the agent should attach:
+
+- The default `MCP_AGENT_LLM=openrouter` requires an `OPENROUTER_KEY`. The
+  service automatically wires the OpenRouter credentials into the embedded
+  agent so no OpenAI API key is needed.
+- To run the agent with OpenAI instead, set `MCP_AGENT_LLM=openai` and provide
+  `OPENAI_API_KEY`.
 
 To inject a custom system prompt at the beginning of every conversation, set
 the `INITIAL_SYSTEM_PROMPT` environment variable (or provide it via the YAML
@@ -114,15 +119,18 @@ settings.
 | Variable | Description | Default |
 | --- | --- | --- |
 | `ADMIN_TOKEN` | Token required for admin endpoints. When unset the admin API is disabled. | `None` |
-| `OPENAI_API_KEY` | API key consumed by the embedded `mcp-agent` LLM. | `None` |
+| `OPENAI_API_KEY` | API key consumed by the embedded `mcp-agent` LLM when `MCP_AGENT_LLM=openai`. | `None` |
+| `OPENROUTER_KEY` | API key used for both the standalone OpenRouter provider and the MCP agent when `MCP_AGENT_LLM=openrouter`. | `None` |
+| `OPENROUTER_BASE_URL` | Override the OpenRouter API endpoint used by both providers. | `https://openrouter.ai/api/v1` |
+| `OPENROUTER_MODEL` | Default OpenRouter model requested when none is supplied explicitly. | `openrouter/auto` |
 | `MCP_SERVER_URL` | Legacy fallback for the deprecated MCP client. | `None` |
 | `MCP_API_KEY` | Optional API key for legacy MCP servers. | `None` |
 | `MCP_AGENT_CONFIG` | Path to an `mcp_agent.config.yaml` describing downstream MCP servers. | `None` |
 | `MCP_AGENT_SERVERS` | Comma separated list of at least two server names to expose to the agent. | `None` |
 | `MCP_AGENT_APP_NAME` | Override the logical name reported by the embedded MCP app. | `chat-backend` |
 | `MCP_AGENT_INSTRUCTION` | Optional instruction passed to the agent instead of `INITIAL_SYSTEM_PROMPT`. | `None` |
-| `MCP_AGENT_LLM` | Identifier for the augmented LLM to attach (currently `openai`). | `openai` |
-| `MCP_AGENT_MODEL` | Default OpenAI model requested by the agent. | `None` |
+| `MCP_AGENT_LLM` | Identifier for the augmented LLM to attach (`openai` or `openrouter`). | `openrouter` |
+| `MCP_AGENT_MODEL` | Default model requested by the agent. Falls back to `OPENROUTER_MODEL` when using OpenRouter. | `None` |
 | `INITIAL_SYSTEM_PROMPT` | System prompt stored when new sessions are created. | `None` |
 | `REDIS_URL` | Enables Redis-backed memory and rate limiting when provided. | `None` |
 | `RATE_RPS` | Average number of requests per second allowed per identity. | `1.0` |

--- a/app/agents/providers/openrouter.py
+++ b/app/agents/providers/openrouter.py
@@ -28,8 +28,8 @@ class OpenRouterChatProvider(ChatProvider):
         self,
         *,
         api_key: Optional[str] = None,
-        model: str = "openrouter/auto",
-        base_url: str = "https://openrouter.ai/api/v1",
+        model: Optional[str] = None,
+        base_url: Optional[str] = None,
         timeout: Optional[float] = None,
         client: Optional[httpx.AsyncClient] = None,
         default_headers: Optional[Mapping[str, str]] = None,
@@ -42,9 +42,10 @@ class OpenRouterChatProvider(ChatProvider):
         if not self._api_key:
             raise OpenRouterProviderError("OpenRouter API key is required to use the provider.")
 
-        self._model = model
+        self._model = model or settings.openrouter_default_model
         self._timeout = timeout or settings.provider_timeout_seconds
-        self._base_url = base_url.rstrip("/")
+        resolved_base_url = base_url or settings.openrouter_base_url
+        self._base_url = resolved_base_url.rstrip("/")
         self._client_owner = client is None
         self._client = client or httpx.AsyncClient(
             base_url=self._base_url,

--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,12 @@ class Settings(BaseSettings):
     admin_token: Optional[str] = Field(default=None, env="ADMIN_TOKEN")
     openai_api_key: Optional[str] = Field(default=None, env="OPENAI_API_KEY")
     openrouter_key: Optional[str] = Field(default=None, env="OPENROUTER_KEY")
+    openrouter_base_url: str = Field(
+        default="https://openrouter.ai/api/v1", env="OPENROUTER_BASE_URL"
+    )
+    openrouter_default_model: str = Field(
+        default="openrouter/auto", env="OPENROUTER_MODEL"
+    )
     mcp_server_url: Optional[str] = Field(default=None, env="MCP_SERVER_URL")
     mcp_api_key: Optional[str] = Field(default=None, env="MCP_API_KEY")
     mcp_agent_config: Optional[str] = Field(default=None, env="MCP_AGENT_CONFIG")
@@ -37,7 +43,7 @@ class Settings(BaseSettings):
     mcp_agent_instruction: Optional[str] = Field(
         default=None, env="MCP_AGENT_INSTRUCTION"
     )
-    mcp_agent_llm_provider: str = Field(default="openai", env="MCP_AGENT_LLM")
+    mcp_agent_llm_provider: str = Field(default="openrouter", env="MCP_AGENT_LLM")
     mcp_agent_default_model: Optional[str] = Field(
         default=None, env="MCP_AGENT_MODEL"
     )
@@ -164,7 +170,7 @@ class Settings(BaseSettings):
     @classmethod
     def _normalise_llm(cls, value: Optional[str]) -> str:
         if not value:
-            return "openai"
+            return "openrouter"
         return str(value).strip().lower()
 
     @property

--- a/tests/test_mcp_openrouter.py
+++ b/tests/test_mcp_openrouter.py
@@ -1,0 +1,58 @@
+import os
+
+import pytest
+
+from app.agents.providers.mcp import MCPAgentChatProvider, MCPAgentProviderError
+from app.config import Settings
+
+
+def _base_settings(**overrides) -> Settings:
+    payload = {
+        "openrouter_key": "sk-or-example",
+        "openrouter_base_url": "https://router.example/api",
+        "openrouter_default_model": "openrouter/example",
+    }
+    payload.update(overrides)
+    return Settings.model_construct(**payload)
+
+
+def test_configure_openrouter_environment_sets_defaults(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_DEFAULT_MODEL", raising=False)
+
+    settings = _base_settings()
+
+    MCPAgentChatProvider._configure_openrouter_environment(settings)
+
+    assert os.environ["OPENAI_API_KEY"] == "sk-or-example"
+    assert os.environ["OPENAI_BASE_URL"] == "https://router.example/api"
+    assert os.environ["OPENAI_DEFAULT_MODEL"] == "openrouter/example"
+
+
+def test_configure_openrouter_environment_prefers_agent_model(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_DEFAULT_MODEL", raising=False)
+
+    settings = _base_settings(mcp_agent_default_model="openrouter/custom")
+
+    MCPAgentChatProvider._configure_openrouter_environment(settings)
+
+    assert os.environ["OPENAI_DEFAULT_MODEL"] == "openrouter/custom"
+
+
+def test_configure_openrouter_environment_requires_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    settings = _base_settings(openrouter_key=None)
+
+    with pytest.raises(MCPAgentProviderError):
+        MCPAgentChatProvider._configure_openrouter_environment(settings)
+
+
+def test_settings_default_llm_is_openrouter(monkeypatch):
+    monkeypatch.delenv("MCP_AGENT_LLM", raising=False)
+
+    settings = Settings()
+
+    assert settings.mcp_agent_llm_provider == "openrouter"


### PR DESCRIPTION
## Summary
- default the embedded MCP agent to the OpenRouter LLM and normalize unset configuration values accordingly
- refresh the README and sample environment file to document the new OpenRouter default
- extend the MCP OpenRouter test coverage to assert the new default provider behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa94ac2f608325bfdcc148a6ce74f5