### PR TITLE
Clarify ham3d MCP server environment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ LOG_LEVEL=INFO
 PROVIDER_TIMEOUT_SECONDS=30
 
 # ham3d MCP server (optional)
+# Populate every field with the credentials for your database before launching
+# `python -m mcp_servers.ham3d_mysql`.
 HAM3D_DB_HOST=127.0.0.1
 HAM3D_DB_PORT=3306
 HAM3D_DB_USER=

--- a/README.md
+++ b/README.md
@@ -71,6 +71,56 @@ and merge it with your own MCP configuration file. The example server expects a
 MySQL database and reads connection information from the `HAM3D_DB_*`
 environment variables (see `.env.example` for the full list).
 
+#### Launch the MCP servers
+
+Start each configured server in its own terminal so the agent can connect over
+`stdio`:
+
+```bash
+npx mcp-server-filesystem
+npx mcp-server-fetch
+```
+
+For the ham3d catalogue server populate the `HAM3D_DB_*` variables **with real
+values** and then run the module from the project root (note the module path
+after `-m`). The server will raise `RuntimeError: Environment variable
+HAM3D_DB_USER must be configured for the ham3d server.` (or similar) if any of
+the required variables are missing or blank.
+
+```bash
+export HAM3D_DB_HOST=127.0.0.1
+export HAM3D_DB_USER=root
+export HAM3D_DB_PASSWORD="super-secret"
+export HAM3D_DB_NAME=ham3dbot_ham3d_shop
+python -m mcp_servers.ham3d_mysql
+```
+
+PowerShell users can set the variables for the current session like this:
+
+```powershell
+$env:HAM3D_DB_HOST = "127.0.0.1"
+$env:HAM3D_DB_USER = "root"
+$env:HAM3D_DB_PASSWORD = "super-secret"
+$env:HAM3D_DB_NAME = "ham3dbot_ham3d_shop"
+```
+
+After exporting the variables, launch the server:
+
+```bash
+python -m mcp_servers.ham3d_mysql
+# Windows PowerShell example when using a virtual environment
+.\.venv\Scripts\python.exe -m mcp_servers.ham3d_mysql
+```
+
+Do not append a filesystem path after `-m`; Python expects an importable module
+name and will raise `No module named ...` if a path is provided.
+
+> **Tip:** Storing the credentials in `.env` is convenient, but Python will not
+> automatically load that file when you start the MCP server directly. Source
+> the file yourself (`set -a && source .env`) or run the command through a
+> helper such as `python -m dotenv run -- python -m mcp_servers.ham3d_mysql` so
+> the environment variables are populated before the module imports.
+
 Choose the LLM the agent should attach:
 
 - The default `MCP_AGENT_LLM=openrouter` requires an `OPENROUTER_KEY`. The


### PR DESCRIPTION
## Summary
- explain that the ham3d MCP server requires non-empty HAM3D_DB_* credentials
- provide bash and PowerShell examples for exporting the variables before launch
- note that `.env` files must be sourced manually when running the module directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb4cd43ff083259871560978cb2f72