### PR TITLE
Handle empty MCP agent server env values

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+"""Tests for the application configuration settings."""
+
+from __future__ import annotations
+
+from app.config import Settings
+
+
+def test_mcp_agent_servers_handles_empty_string(monkeypatch):
+    """An empty environment variable should yield an empty list."""
+
+    monkeypatch.setenv("MCP_AGENT_SERVERS", "")
+    settings = Settings()
+    assert settings.mcp_agent_servers == []
+
+
+def test_mcp_agent_servers_parses_comma_separated(monkeypatch):
+    """Comma separated entries should be normalised into a list."""
+
+    monkeypatch.setenv("MCP_AGENT_SERVERS", "alpha , beta,gamma")
+    settings = Settings()
+    assert settings.mcp_agent_servers == ["alpha", "beta", "gamma"]
+
+
+def test_mcp_agent_servers_parses_json_array(monkeypatch):
+    """JSON arrays remain supported for backwards compatibility."""
+
+    monkeypatch.setenv("MCP_AGENT_SERVERS", '["delta", "epsilon"]')
+    settings = Settings()
+    assert settings.mcp_agent_servers == ["delta", "epsilon"]


### PR DESCRIPTION
## Summary
- add a tolerant environment settings source to avoid JSON decode errors when MCP agent server values are plain strings
- expand the MCP agent server validator to handle empty, comma-separated, and JSON array inputs
- add regression tests covering the supported MCP agent server environment values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fb7ed53248832598e7bb44253ac518