### PR TITLE
Use bind mounts for Docker development

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,14 +6,23 @@ these Dockerfiles, so reference it explicitly (for example with
 `docker compose -f docker/docker-compose.yml ...`) when launching services from
 the project root.
 
+Both the API and MCP containers now expect the project source to be mounted in
+at runtime rather than copied into the image. The compose file binds the
+repository root to `/app`, so edits on your machine (including Windows hosts)
+are visible immediately inside the containers. Make sure Docker BuildKit is
+enabled (it is on by default for recent Docker Desktop releases) so the
+Dockerfiles can access `requirements.txt` via a temporary bind mount during the
+image build.
+
 ## Images
 
 - `api.Dockerfile` – Builds the FastAPI application image that powers the chat
   service. The resulting container runs `uvicorn app.main:app` as a non-root
-  user.
+  user. Dependencies are installed during the build using BuildKit bind mounts,
+  so the source tree does not need to be copied into the image.
 - `ham3d.Dockerfile` – Packages the ham3d MySQL-backed MCP server. The entry
   point launches `python -m mcp_servers.ham3d_mysql` so the MCP agent can
-  connect over stdio.
+  connect over stdio, again relying on the runtime bind mount for code access.
 
 Both images install dependencies from `requirements.txt`. Provide database
 credentials for the ham3d server via environment variables before starting the

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.6
 FROM python:3.11-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -6,13 +6,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-COPY requirements.txt ./
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
-
-COPY app ./app
-COPY mcp_servers ./mcp_servers
-COPY README.md ./README.md
+RUN --mount=type=bind,source=requirements.txt,target=/tmp/requirements.txt \
+    pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/requirements.txt
 
 RUN useradd --create-home appuser
 USER appuser

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - REDIS_URL=redis://redis:6379/0
     env_file:
       - ../.env
+    volumes:
+      - ../:/app
     depends_on:
       - redis
   redis:
@@ -26,5 +28,7 @@ services:
       - ../.env
     stdin_open: true
     tty: true
+    volumes:
+      - ../:/app
 volumes:
   redis-data:

--- a/docker/ham3d.Dockerfile
+++ b/docker/ham3d.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.6
 FROM python:3.11-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -6,11 +6,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-COPY requirements.txt ./
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
-
-COPY mcp_servers ./mcp_servers
+RUN --mount=type=bind,source=requirements.txt,target=/tmp/requirements.txt \
+    pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/requirements.txt
 
 RUN useradd --create-home mcpuser
 USER mcpuser


### PR DESCRIPTION
## Summary
- update the FastAPI and ham3d Dockerfiles to install dependencies via BuildKit bind mounts instead of copying source files
- mount the project directory into the API and MCP containers so local code is used at runtime
- document the new bind-mount workflow and BuildKit requirement in docker/README.md

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fb822c14308325be2952b25da4c090