### PR TITLE
Move ham3d MCP server env settings to dedicated sample file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,17 +37,5 @@ METRICS_ENABLED=true
 LOG_LEVEL=INFO
 PROVIDER_TIMEOUT_SECONDS=30
 
-# ham3d MCP server (optional)
-# Populate every field with the credentials for your database before launching
-# `python -m mcp_servers.ham3d_mysql`.
-HAM3D_DB_HOST=127.0.0.1
-HAM3D_DB_PORT=3306
-HAM3D_DB_USER=
-HAM3D_DB_PASSWORD=
-HAM3D_DB_NAME=ham3d
-HAM3D_DB_POOL_MIN_SIZE=1
-HAM3D_DB_POOL_MAX_SIZE=10
-HAM3D_DB_CONNECT_TIMEOUT=10
-
 # Optional path to a YAML config file for advanced deployments
 # APP_CONFIG_FILE=/etc/chat-agent/config.yaml

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ to expose the ham3d catalogue search server defined in
 `mcp_servers/ham3d_mysql.py`, copy `examples/mcp_agent.ham3d.config.yaml`
 and merge it with your own MCP configuration file. The example server expects a
 MySQL database and reads connection information from the `HAM3D_DB_*`
-environment variables (see `.env.example` for the full list).
+environment variables (see `mcp_servers/.env.ham3d.example` for the defaults).
 
 #### Launch the MCP servers
 
@@ -121,18 +121,22 @@ python -m mcp_servers.ham3d_mysql
 > docker compose -f docker/docker-compose.yml --profile mcp build mcp-ham3d
 > docker compose -f docker/docker-compose.yml --profile mcp run --rm mcp-ham3d
 > ```
->
-> Populate the `HAM3D_DB_*` variables in `.env` (or pass them inline) before
-> running the container so the server can connect to your database.
+
+Populate the `HAM3D_DB_*` variables with valid credentials before running the
+container so the server can connect to your database. You can copy
+`mcp_servers/.env.ham3d.example` to `mcp_servers/.env.ham3d` and update the
+values, then load them via `set -a && source mcp_servers/.env.ham3d`.
 
 Do not append a filesystem path after `-m`; Python expects an importable module
 name and will raise `No module named ...` if a path is provided.
 
-> **Tip:** Storing the credentials in `.env` is convenient, but Python will not
-> automatically load that file when you start the MCP server directly. Source
-> the file yourself (`set -a && source .env`) or run the command through a
-> helper such as `python -m dotenv run -- python -m mcp_servers.ham3d_mysql` so
-> the environment variables are populated before the module imports.
+> **Tip:** Storing the credentials in `mcp_servers/.env.ham3d` (or another
+> dedicated env file) is convenient, but Python will not automatically load that
+> file when you start the MCP server directly. Source the file yourself
+> (`set -a && source mcp_servers/.env.ham3d`) or run the command through a
+> helper such as
+> `python -m dotenv run --dotenv-path mcp_servers/.env.ham3d -- python -m mcp_servers.ham3d_mysql`
+> so the environment variables are populated before the module imports.
 
 Choose the LLM the agent should attach:
 

--- a/mcp_servers/.env.ham3d.example
+++ b/mcp_servers/.env.ham3d.example
@@ -1,0 +1,11 @@
+# ham3d MCP server configuration
+# Copy this file to `.env.ham3d` (or similar) and adjust values for your
+# environment before starting `python -m mcp_servers.ham3d_mysql`.
+HAM3D_DB_HOST=127.0.0.1
+HAM3D_DB_PORT=3306
+HAM3D_DB_USER=root
+HAM3D_DB_PASSWORD=
+HAM3D_DB_NAME=ham3dbot_ham3d_shop
+HAM3D_DB_POOL_MIN_SIZE=1
+HAM3D_DB_POOL_MAX_SIZE=10
+HAM3D_DB_CONNECT_TIMEOUT=10

--- a/mcp_servers/ham3d_mysql.py
+++ b/mcp_servers/ham3d_mysql.py
@@ -451,9 +451,9 @@ async def lifespan(_: FastMCP) -> Iterable[Ham3DLifespanContext]:
 
     host = _db_env("HAM3D_DB_HOST", "127.0.0.1")
     port = int(_db_env("HAM3D_DB_PORT", "3306"))
-    user = _db_env("HAM3D_DB_USER", required=True)
+    user = _db_env("HAM3D_DB_USER", "root", required=True)
     password = _db_env("HAM3D_DB_PASSWORD", "")
-    database = _db_env("HAM3D_DB_NAME", "ham3d")
+    database = _db_env("HAM3D_DB_NAME", "ham3dbot_ham3d_shop")
     minsize = max(1, int(_db_env("HAM3D_DB_POOL_MIN_SIZE", "1")))
     maxsize = max(minsize, int(_db_env("HAM3D_DB_POOL_MAX_SIZE", "10")))
     connect_timeout = float(_db_env("HAM3D_DB_CONNECT_TIMEOUT", "10"))

--- a/tests/test_provider_registration.py
+++ b/tests/test_provider_registration.py
@@ -1,0 +1,60 @@
+"""Tests covering automatic provider registration during app start-up."""
+
+from __future__ import annotations
+
+from app.agents.manager import ProviderManager
+from app.config import get_settings
+from app.dependencies import get_provider_manager, set_provider_manager
+from app.main import create_app
+
+
+def _reset_settings_cache() -> None:
+    """Utility to reset the cached settings between tests."""
+
+    get_settings.cache_clear()
+
+
+def test_create_app_registers_openrouter_provider(monkeypatch):
+    """Providing an OpenRouter key should register the provider by default."""
+
+    monkeypatch.setenv("OPENROUTER_KEY", "sk-or-example")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("MCP_AGENT_SERVERS", raising=False)
+
+    _reset_settings_cache()
+
+    original_manager = get_provider_manager()
+    manager = ProviderManager()
+    set_provider_manager(manager)
+
+    try:
+        create_app()
+        available = manager.available()
+        assert "openrouter" in available
+        assert manager.default == "openrouter"
+    finally:
+        set_provider_manager(original_manager)
+        _reset_settings_cache()
+
+
+def test_create_app_registers_openai_provider(monkeypatch):
+    """Providing an OpenAI key should register the OpenAI provider."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENROUTER_KEY", raising=False)
+    monkeypatch.delenv("MCP_AGENT_SERVERS", raising=False)
+
+    _reset_settings_cache()
+
+    original_manager = get_provider_manager()
+    manager = ProviderManager()
+    set_provider_manager(manager)
+
+    try:
+        create_app()
+        available = manager.available()
+        assert "openai" in available
+        assert manager.default == "openai"
+    finally:
+        set_provider_manager(original_manager)
+        _reset_settings_cache()


### PR DESCRIPTION
## Summary
- move the ham3d MCP server environment variables out of the main `.env.example` and into `mcp_servers/.env.ham3d.example`
- document loading the dedicated ham3d env file and link to it from the setup instructions
- update the ham3d MCP server defaults to use the new sample values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fb8e6f9ab08325841ef313c48f13a9