### PR TITLE
Enforce OpenRouter default provider configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,15 @@ This repository hosts the FastAPI-based AI chat bot service. Follow these guidel
    - When adding new runnable services or programs, place their Dockerfiles inside the `docker/` directory and update `docker/docker-compose.yml` accordingly.
 
 These instructions apply to the entire repository.
+
+## Provider configuration reminders
+- The backend must always communicate with the primary agent through the
+  OpenRouter API by default. Keep OpenRouter registered and selected through
+  environment variables (for example `OPENROUTER_KEY` and
+  `DEFAULT_PROVIDER`).
+- Provider selection must never be exposed to, or configurable from, any
+  public API surface or example client. All routing changes happen through the
+  environment only.
+- Support optional MCP servers that attach to the agent via environment
+  configuration. The system should operate without MCP settings when they are
+  omitted, and default to OpenRouter-only behaviour.

--- a/app/agents/manager.py
+++ b/app/agents/manager.py
@@ -176,19 +176,9 @@ class ProviderManager:
     def resolve_for_session(
         self,
         *,
-        request_override: Optional[str] = None,
         session_provider: Optional[str] = None,
     ) -> "ProviderManager.ProviderResolution":
-        """Resolve a provider with awareness of session defaults and overrides."""
-
-        if request_override:
-            normalised = self._normalise_name(request_override)
-            provider = self.get(normalised)
-            return self.ProviderResolution(
-                name=normalised,
-                provider=provider,
-                source="override",
-            )
+        """Resolve a provider with awareness of session defaults."""
 
         if session_provider:
             normalised = self._normalise_name(session_provider)
@@ -250,13 +240,11 @@ class ProviderManager:
         self,
         *,
         session: Optional["Session"] = None,
-        request_override: Optional[str] = None,
     ) -> "ProviderManager.ProviderResolution":
         """Resolve a provider using the supplied session model when available."""
 
         session_provider = session.provider if session is not None else None
         return self.resolve_for_session(
-            request_override=request_override,
             session_provider=session_provider,
         )
 

--- a/app/main.py
+++ b/app/main.py
@@ -163,6 +163,13 @@ def create_app() -> FastAPI:
                 extra={"requested_provider": desired_default},
             )
 
+    if manager.default is None:
+        raise RuntimeError(
+            "No chat provider configured. Set OPENROUTER_KEY (and related "
+            "environment variables) so the OpenRouter backend registers as the "
+            "default provider before starting the API."
+        )
+
     @application.middleware("http")
     async def _logging_middleware(
         request: Request,

--- a/examples/basic_session.py
+++ b/examples/basic_session.py
@@ -87,8 +87,7 @@ async def main(config: ExampleConfig) -> None:
 
         session = response.json()
         session_id = session["id"]
-        provider = session.get("provider") or "<service default>"
-        print(f"Created session {session_id} with provider {provider}")
+        print(f"Created session {session_id}")
 
         try:
             message_payload: dict[str, Any] = {
@@ -112,11 +111,7 @@ async def main(config: ExampleConfig) -> None:
 
             payload = message_response.json()
             assistant = payload["message"]["content"]
-            provider_name = payload.get("provider")
-            provider_source = payload.get("provider_source")
-            print(
-                f"Assistant replied (provider={provider_name}, source={provider_source}):"
-            )
+            print("Assistant replied:")
             print(assistant)
             if usage := payload.get("usage"):
                 print("Usage metrics:")

--- a/examples/chat.html
+++ b/examples/chat.html
@@ -288,15 +288,6 @@
       color: var(--accent);
     }
 
-    .pill {
-      padding: 0.2rem 0.55rem;
-      border-radius: 999px;
-      background: rgba(56, 189, 248, 0.15);
-      color: var(--accent);
-      font-size: 0.7rem;
-      font-weight: 600;
-    }
-
     .hidden {
       display: none;
     }
@@ -368,7 +359,6 @@
       <div class="meta">
         <span class="group">
           <span class="role"></span>
-          <span class="pill provider"></span>
         </span>
         <span class="timestamp"></span>
       </div>
@@ -394,9 +384,6 @@
     const messageOptionsInput = document.getElementById('messageOptions');
 
     let sessionId = null;
-    let sessionProvider = null;
-    let sessionFallback = null;
-
     const formatDateTime = (value) => {
       const date = value instanceof Date ? value : new Date(value);
       return new Intl.DateTimeFormat('fa-IR', {
@@ -404,15 +391,6 @@
         minute: '2-digit',
         second: '2-digit'
       }).format(date);
-    };
-
-    const formatProviderLabel = (name, source) => {
-      if (!name) return '';
-      if (!source || source === 'session') {
-        return name;
-      }
-      const sourceLabel = source === 'fallback' ? 'fallback' : source;
-      return `${name} • ${sourceLabel}`;
     };
 
     const parseJsonField = (value, label) => {
@@ -456,21 +434,13 @@
       return JSON.stringify(payload, null, 2);
     };
 
-    function appendMessage({ role, content, provider, timestamp = new Date(), metadata = null }) {
+    function appendMessage({ role, content, timestamp = new Date(), metadata = null }) {
       const node = messageTemplate.content.firstElementChild.cloneNode(true);
       node.classList.toggle('user', role === 'user');
       node.dataset.role = role;
       node.querySelector('.role').textContent = role === 'assistant' ? 'دستیار' : role === 'system' ? 'سیستم' : 'کاربر';
       node.querySelector('.timestamp').textContent = formatDateTime(timestamp);
       node.querySelector('.body').textContent = content;
-
-      const providerEl = node.querySelector('.provider');
-      if (provider) {
-        providerEl.textContent = provider;
-        providerEl.classList.remove('hidden');
-      } else {
-        providerEl.classList.add('hidden');
-      }
 
       const metadataEl = node.querySelector('.metadata');
       if (metadata && Object.keys(metadata).length > 0) {
@@ -541,10 +511,7 @@
         }
 
         sessionId = data.id;
-        sessionProvider = data.provider || 'پیش‌فرض سرویس';
-        sessionFallback = data.fallback_provider || null;
-        const fallbackText = sessionFallback ? `، پشتیبان: <strong>${sessionFallback}</strong>` : '';
-        sessionStatus.innerHTML = `سشن فعال: <strong>${sessionId}</strong> (پرووایدر: <strong>${sessionProvider}</strong>${fallbackText})`;
+        sessionStatus.innerHTML = `سشن فعال: <strong>${sessionId}</strong>`;
         deleteSessionBtn.classList.remove('hidden');
         messageInput.disabled = false;
         sendBtn.disabled = false;
@@ -552,7 +519,6 @@
         appendMessage({
           role: 'assistant',
           content: 'سشن با موفقیت ساخته شد! حالا پیام خود را ارسال کن.',
-          provider: sessionProvider,
           metadata: Object.keys(data.metadata || {}).length ? data.metadata : null
         });
         requestStatus.textContent = '';
@@ -561,8 +527,6 @@
         requestStatus.textContent = 'ساخت سشن با خطا مواجه شد.';
         sessionStatus.textContent = error.message || 'سشنی ساخته نشده است.';
         sessionId = null;
-        sessionProvider = null;
-        sessionFallback = null;
         deleteSessionBtn.classList.add('hidden');
         messageInput.disabled = true;
         sendBtn.disabled = true;
@@ -582,16 +546,13 @@
         console.warn('حذف سشن با خطا مواجه شد', error);
       }
       sessionId = null;
-      sessionProvider = null;
-      sessionFallback = null;
       sessionStatus.textContent = 'سشنی ساخته نشده است.';
       messageInput.disabled = true;
       sendBtn.disabled = true;
       deleteSessionBtn.classList.add('hidden');
       appendMessage({
         role: 'assistant',
-        content: 'سشن بسته شد.',
-        provider: null
+        content: 'سشن بسته شد.'
       });
       requestStatus.textContent = '';
     }
@@ -613,7 +574,7 @@
         return;
       }
 
-      appendMessage({ role: 'user', content, provider: 'شما', timestamp: new Date() });
+      appendMessage({ role: 'user', content, timestamp: new Date() });
       setLoading(true, 'در انتظار پاسخ سرور');
 
       try {
@@ -641,22 +602,19 @@
           throw new Error(message);
         }
 
-        const providerLabel = formatProviderLabel(data.provider, data.provider_source);
         appendMessage({
           role: data.message.role,
           content: data.message.content,
-          provider: providerLabel || sessionProvider,
           timestamp: data.message.created_at,
           metadata: data.message.metadata || null
         });
-        setLoading(false, providerLabel ? `پاسخ از ${providerLabel}` : 'پاسخ دریافت شد.');
+        setLoading(false, 'پاسخ دریافت شد.');
       } catch (error) {
         console.error(error);
         setLoading(false, 'خطا در ارسال پیام.');
         appendMessage({
           role: 'assistant',
-          content: error.message || 'خطای ناشناخته',
-          provider: 'خطا'
+          content: error.message || 'خطای ناشناخته'
         });
       }
     }

--- a/tests/test_metrics_toggle.py
+++ b/tests/test_metrics_toggle.py
@@ -3,13 +3,32 @@
 from __future__ import annotations
 
 import asyncio
+import os
+
+os.environ.setdefault("OPENROUTER_KEY", "sk-or-test")
 
 from fastapi.testclient import TestClient
 
 from app import dependencies
+from app.agents.manager import (
+    ChatMessage as ProviderChatMessage,
+    ChatResponse,
+    ProviderManager,
+)
 from app.config import Settings
 from app.main import create_app
 from app.observability import MetricsCollector
+
+
+class _SilentProvider:
+    name = "openrouter"
+
+    async def chat(self, messages, **options):  # type: ignore[override]
+        return ChatResponse(
+            message=ProviderChatMessage(role="assistant", content="placeholder"),
+            raw={},
+            usage={},
+        )
 
 
 def _override_settings(monkeypatch, **overrides) -> None:
@@ -22,40 +41,67 @@ def _override_settings(monkeypatch, **overrides) -> None:
 def test_metrics_enabled_records_requests(monkeypatch) -> None:
     """When metrics are enabled the middleware should record request counts."""
 
+    original_manager = dependencies.get_provider_manager()
+    original_metrics = dependencies.get_metrics_collector()
+
+    manager = ProviderManager()
+    provider = _SilentProvider()
+    manager.register(provider)
+    manager.set_default(provider.name)
+
+    dependencies.set_provider_manager(manager)
     dependencies.set_metrics_collector(MetricsCollector())
     _override_settings(monkeypatch, metrics_enabled=True)
 
-    app = create_app()
-    client = TestClient(app)
+    try:
+        app = create_app()
+        client = TestClient(app)
 
-    before = asyncio.run(dependencies.get_metrics_collector().snapshot())
-    response = client.get("/")
-    assert response.status_code == 200
-    metrics_response = client.get("/metrics")
-    assert metrics_response.status_code == 200
+        before = asyncio.run(dependencies.get_metrics_collector().snapshot())
+        response = client.get("/")
+        assert response.status_code == 200
+        metrics_response = client.get("/metrics")
+        assert metrics_response.status_code == 200
 
-    after = asyncio.run(dependencies.get_metrics_collector().snapshot())
-    assert after["requests_total"] > before["requests_total"]
-    assert "/metrics" in {route.path for route in app.router.routes}
+        after = asyncio.run(dependencies.get_metrics_collector().snapshot())
+        assert after["requests_total"] > before["requests_total"]
+        assert "/metrics" in {route.path for route in app.router.routes}
+    finally:
+        dependencies.set_provider_manager(original_manager)
+        dependencies.set_metrics_collector(original_metrics)
 
 
 def test_metrics_disabled_hides_route_and_middleware(monkeypatch) -> None:
     """Disabling metrics removes the route and stops counters from changing."""
 
+    original_manager = dependencies.get_provider_manager()
+    original_metrics = dependencies.get_metrics_collector()
+
+    manager = ProviderManager()
+    provider = _SilentProvider()
+    manager.register(provider)
+    manager.set_default(provider.name)
+
+    dependencies.set_provider_manager(manager)
     dependencies.set_metrics_collector(MetricsCollector())
     _override_settings(monkeypatch, metrics_enabled=False)
 
-    app = create_app()
-    client = TestClient(app)
+    try:
+        app = create_app()
+        client = TestClient(app)
 
-    assert "/metrics" not in {route.path for route in app.router.routes}
+        assert "/metrics" not in {route.path for route in app.router.routes}
 
-    missing = client.get("/metrics")
-    assert missing.status_code == 404
+        missing = client.get("/metrics")
+        assert missing.status_code == 404
 
-    before = asyncio.run(dependencies.get_metrics_collector().snapshot())
-    health = client.get("/health")
-    assert health.status_code == 200
-    client.get("/")
-    after = asyncio.run(dependencies.get_metrics_collector().snapshot())
-    assert after["requests_total"] == before["requests_total"]
+        before = asyncio.run(dependencies.get_metrics_collector().snapshot())
+        health = client.get("/health")
+        assert health.status_code == 200
+        client.get("/")
+        after = asyncio.run(dependencies.get_metrics_collector().snapshot())
+        assert after["requests_total"] == before["requests_total"]
+    finally:
+        dependencies.set_provider_manager(original_manager)
+        dependencies.set_metrics_collector(original_metrics)
+


### PR DESCRIPTION
## Summary
- fail fast during application startup when no provider is registered so deployments must supply the environment-backed OpenRouter defaults
- clarify documentation and repository guidance so provider routing is only adjustable via environment variables
- update tests to bootstrap stub providers and seed OpenRouter environment keys for startup checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fba2c112988325966908cf8c0b5a62