### PR TITLE
Handle blank MCP server env values without JSON errors

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -84,7 +84,11 @@ class Settings(BaseSettings):
     mcp_server_url: Optional[str] = Field(default=None, env="MCP_SERVER_URL")
     mcp_api_key: Optional[str] = Field(default=None, env="MCP_API_KEY")
     mcp_agent_config: Optional[str] = Field(default=None, env="MCP_AGENT_CONFIG")
-    mcp_agent_servers: list[str] = Field(default_factory=list, env="MCP_AGENT_SERVERS")
+    mcp_agent_servers: list[str] = Field(
+        default_factory=list,
+        env="MCP_AGENT_SERVERS",
+        metadata=[NoDecode()],
+    )
     mcp_agent_app_name: str = Field(default="chat-backend", env="MCP_AGENT_APP_NAME")
     mcp_agent_instruction: Optional[str] = Field(
         default=None, env="MCP_AGENT_INSTRUCTION"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,3 +27,13 @@ def test_mcp_agent_servers_parses_json_array(monkeypatch):
     monkeypatch.setenv("MCP_AGENT_SERVERS", '["delta", "epsilon"]')
     settings = Settings()
     assert settings.mcp_agent_servers == ["delta", "epsilon"]
+
+
+def test_mcp_agent_servers_blank_dotenv(tmp_path, monkeypatch):
+    """Blank values coming from a dotenv file should not raise errors."""
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("MCP_AGENT_SERVERS=\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    settings = Settings()
+    assert settings.mcp_agent_servers == []


### PR DESCRIPTION
## Summary
- prevent the MCP_AGENT_SERVERS setting from being pre-decoded as JSON so blank dotenv entries no longer raise
- keep parsing logic in the validator and add a regression test that loads the setting from a dotenv file

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68fbabc0bcf48325894ddc8dbfbc8e25