### PR TITLE
Refocus runtime on the MCP agent provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,11 @@ These instructions apply to the entire repository.
 - Configuration for `mcp-agent` comes solely from the environment / config
   files (for local development, `.env`). Never add request parameters, query
   flags, or UI controls that alter provider choice.
-- By default `mcp-agent` calls the OpenRouter API. Ensure the required
-  OpenRouter credentials (for example `OPENROUTER_KEY`) are read from the
-  configuration layer so every chat request is proxied through OpenRouter.
-- Support optional MCP servers by reading `MCP_AGENT_SERVERS` from the
-  configuration. When this value is provided, `mcp-agent` must include those
-  servers when chatting. When it is absent, the agent must behave exactly like
-  the OpenRouter-only flow.
+- `mcp-agent` always serves requests. When no MCP servers are configured it
+  must transparently delegate to OpenRouter using the credentials supplied via
+  configuration. Optional MCP servers are added **only** when
+  `MCP_AGENT_SERVERS` is provided, in which case the agent should fan out to
+  those servers. Leaving the value blank must keep the OpenRouter-only flow.
+- OpenRouter (or another configured LLM backend) may only be changed through
+  configuration values such as `MCP_AGENT_LLM` and `MCP_AGENT_MODEL`. Runtime
+  toggles or ad-hoc request parameters are prohibited.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ override individual values via `docker run -e ...` or your orchestrator. At a
 minimum set `openrouter_key` (or `OPENROUTER_KEY`) so the service can
 authenticate with the OpenRouter API and configure an `admin_token` if you want
 to access the admin endpoints. The bundled configuration pins
-`default_provider_name: openrouter`, so once credentials are provided the
-service automatically uses the OpenRouter backend.
+`default_provider_name: mcp-agent`, so once credentials are provided every chat
+request runs through the embedded MCP agent, which uses OpenRouter as its
+default LLM backend.
 
 If you prefer traditional dotenv workflows copy `.env.example` to `.env`. Any
 values defined in `.env` or directly in the process environment override the
@@ -62,11 +63,12 @@ cp .env.example .env
 # edit .env
 ```
 
-When `MCP_AGENT_SERVERS` lists at least two server identifiers the application
-automatically registers an `MCPAgentChatProvider`. The provider loads its
-server catalogue from the `mcp_agent.config.yaml` file referenced by
-`MCP_AGENT_CONFIG`. A minimal configuration that connects to both the
-filesystem and fetch reference servers looks like this:
+When `MCP_AGENT_SERVERS` lists one or more server identifiers the application
+automatically enables MCP server orchestration within the
+`MCPAgentChatProvider`. The provider loads its server catalogue from the
+`mcp_agent.config.yaml` file referenced by `MCP_AGENT_CONFIG`. A minimal
+configuration that connects to both the filesystem and fetch reference servers
+looks like this:
 
 ```yaml
 # mcp_agent.config.yaml
@@ -86,8 +88,8 @@ mcp:
         - mcp-server-fetch
 ```
 
-Set `MCP_AGENT_SERVERS=filesystem,fetch` (or any other two entries defined in
-the configuration file) and choose the LLM the agent should attach. If you want
+Set `MCP_AGENT_SERVERS=filesystem,fetch` (or any other entries defined in the
+configuration file) and choose the LLM the agent should attach. If you want
 to expose the ham3d catalogue search server defined in
 `mcp_servers/ham3d_mysql.py`, reference the bundled
 `mcp_servers/ham3d_mysql/config/mcp_agent.config.yaml` from your MCP agent
@@ -228,14 +230,14 @@ settings.
 | Variable | Description | Default |
 | --- | --- | --- |
 | `ADMIN_TOKEN` | Token required for admin endpoints. When unset the admin API is disabled. | `None` |
-| `DEFAULT_PROVIDER` | Name of the provider the backend uses for every request. Clients cannot override this value. | `openrouter` |
-| `OPENROUTER_KEY` | API key used for both the standalone OpenRouter provider and the MCP agent when `MCP_AGENT_LLM=openrouter`. | `None` |
-| `OPENROUTER_BASE_URL` | Override the OpenRouter API endpoint used by both providers. | `https://openrouter.ai/api/v1` |
+| `DEFAULT_PROVIDER` | Name of the provider the backend uses for every request. Clients cannot override this value. | `mcp-agent` |
+| `OPENROUTER_KEY` | API key used by the MCP agent when `MCP_AGENT_LLM=openrouter`. | `None` |
+| `OPENROUTER_BASE_URL` | Override the OpenRouter API endpoint used by the MCP agent. | `https://openrouter.ai/api/v1` |
 | `OPENROUTER_MODEL` | Default OpenRouter model requested when none is supplied explicitly. | `openrouter/auto` |
 | `MCP_SERVER_URL` | Legacy fallback for the deprecated MCP client. | `None` |
 | `MCP_API_KEY` | Optional API key for legacy MCP servers. | `None` |
 | `MCP_AGENT_CONFIG` | Path to an `mcp_agent.config.yaml` describing downstream MCP servers. | `None` |
-| `MCP_AGENT_SERVERS` | Comma separated list of at least two server names to expose to the agent. | `None` |
+| `MCP_AGENT_SERVERS` | Comma separated list of MCP server names to expose to the agent. Leave blank to run the agent without MCP servers. | `None` |
 | `MCP_AGENT_APP_NAME` | Override the logical name reported by the embedded MCP app. | `chat-backend` |
 | `MCP_AGENT_INSTRUCTION` | Optional instruction passed to the agent instead of `INITIAL_SYSTEM_PROMPT`. | `None` |
 | `MCP_AGENT_LLM` | Identifier for the augmented LLM to attach (`openai` or `openrouter`). | `openrouter` |

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -102,7 +102,7 @@ class Settings(BaseSettings):
         default="openrouter/auto", env="OPENROUTER_MODEL"
     )
     default_provider_name: str = Field(
-        default="openrouter", env="DEFAULT_PROVIDER"
+        default="mcp-agent", env="DEFAULT_PROVIDER"
     )
     mcp_server_url: Optional[str] = Field(default=None, env="MCP_SERVER_URL")
     mcp_api_key: Optional[str] = Field(default=None, env="MCP_API_KEY")
@@ -116,7 +116,10 @@ class Settings(BaseSettings):
     mcp_agent_instruction: Optional[str] = Field(
         default=None, env="MCP_AGENT_INSTRUCTION"
     )
-    mcp_agent_llm_provider: str = Field(default="openrouter", env="MCP_AGENT_LLM")
+    mcp_agent_llm_provider: str = Field(
+        default="openrouter",
+        validation_alias=AliasChoices("MCP_AGENT_LLM", "MCP_AGENT_LLM_PROVIDER"),
+    )
     mcp_agent_default_model: Optional[str] = Field(
         default=None, env="MCP_AGENT_MODEL"
     )
@@ -246,10 +249,10 @@ class Settings(BaseSettings):
     @classmethod
     def _normalise_default_provider(cls, value: Any) -> str:
         if value is None:
-            return "openrouter"
+            return "mcp-agent"
         if isinstance(value, str):
             trimmed = value.strip()
-            return trimmed or "openrouter"
+            return trimmed or "mcp-agent"
         return str(value)
 
     @field_validator("mcp_agent_servers", mode="before")

--- a/app/config/app.config.example.yaml
+++ b/app/config/app.config.example.yaml
@@ -3,7 +3,7 @@
 
 admin_token: change-me
 
-default_provider_name: openrouter
+default_provider_name: mcp-agent
 openrouter_key: null
 openrouter_base_url: https://openrouter.ai/api/v1
 openrouter_default_model: openrouter/auto

--- a/app/main.py
+++ b/app/main.py
@@ -15,10 +15,6 @@ from .agents.manager import ProviderNotRegisteredError
 from .agents.providers import (
     MCPAgentChatProvider,
     MCPAgentProviderError,
-    OpenAIChatProvider,
-    OpenAIProviderError,
-    OpenRouterChatProvider,
-    OpenRouterProviderError,
     UnconfiguredChatProvider,
 )
 from .config import get_settings
@@ -128,38 +124,15 @@ def create_app() -> FastAPI:
         if callable(close_callback):
             shutdown_callbacks.append(close_callback)
 
-    if settings.openrouter_key:
-        try:
-            provider = OpenRouterChatProvider()
-        except OpenRouterProviderError as exc:
-            provider_logger.error(
-                "openrouter_provider_registration_failed",
-                extra={"error": str(exc)},
-            )
-        else:
-            _register_provider(provider)
-
-    if settings.openai_api_key:
-        try:
-            provider = OpenAIChatProvider()
-        except OpenAIProviderError as exc:
-            provider_logger.error(
-                "openai_provider_registration_failed",
-                extra={"error": str(exc)},
-            )
-        else:
-            _register_provider(provider)
-
-    if settings.mcp_agent_servers:
-        try:
-            provider = MCPAgentChatProvider.from_settings(settings)
-        except MCPAgentProviderError as exc:
-            provider_logger.error(
-                "mcp_provider_registration_failed",
-                extra={"error": str(exc)},
-            )
-        else:
-            _register_provider(provider)
+    try:
+        provider = MCPAgentChatProvider.from_settings(settings)
+    except MCPAgentProviderError as exc:
+        provider_logger.error(
+            "mcp_provider_registration_failed",
+            extra={"error": str(exc)},
+        )
+    else:
+        _register_provider(provider)
 
     desired_default = (settings.default_provider_name or "").strip()
     if desired_default:

--- a/app/runtime.py
+++ b/app/runtime.py
@@ -8,7 +8,7 @@ from .config import Settings, get_settings
 from .dependencies import get_chat_memory, get_provider_manager
 
 
-_MIN_MCP_SERVERS: int = 2
+_MIN_MCP_SERVERS: int = 1
 
 
 def build_runtime_report(

--- a/tests/test_metrics_toggle.py
+++ b/tests/test_metrics_toggle.py
@@ -21,7 +21,7 @@ from app.observability import MetricsCollector
 
 
 class _SilentProvider:
-    name = "openrouter"
+    name = "mcp-agent"
 
     async def chat(self, messages, **options):  # type: ignore[override]
         return ChatResponse(

--- a/tests/test_provider_registration.py
+++ b/tests/test_provider_registration.py
@@ -20,13 +20,14 @@ def _reset_settings_cache() -> None:
     get_settings.cache_clear()
 
 
-def test_create_app_registers_openrouter_provider(monkeypatch):
-    """Providing an OpenRouter key should register the provider by default."""
+def test_create_app_registers_mcp_agent_provider_by_default(monkeypatch):
+    """Supplying OpenRouter credentials should register the MCP agent provider."""
 
     monkeypatch.setenv("OPENROUTER_KEY", "sk-or-example")
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("MCP_AGENT_SERVERS", raising=False)
+    monkeypatch.delenv("MCP_AGENT_LLM", raising=False)
 
     _reset_settings_cache()
 
@@ -37,17 +38,18 @@ def test_create_app_registers_openrouter_provider(monkeypatch):
     try:
         create_app()
         available = manager.available()
-        assert "openrouter" in available
-        assert manager.default == "openrouter"
+        assert set(available) == {"mcp-agent"}
+        assert manager.default == "mcp-agent"
     finally:
         set_provider_manager(original_manager)
         _reset_settings_cache()
 
 
-def test_create_app_registers_openai_provider(monkeypatch):
-    """Providing an OpenAI key should register the OpenAI provider."""
+def test_create_app_supports_openai_llm_fallback(monkeypatch):
+    """When configured the MCP agent should use OpenAI as its LLM backend."""
 
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("MCP_AGENT_LLM", "openai")
     monkeypatch.delenv("OPENROUTER_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.delenv("MCP_AGENT_SERVERS", raising=False)
@@ -61,8 +63,8 @@ def test_create_app_registers_openai_provider(monkeypatch):
     try:
         create_app()
         available = manager.available()
-        assert "openai" in available
-        assert manager.default == "openai"
+        assert set(available) == {"mcp-agent"}
+        assert manager.default == "mcp-agent"
     finally:
         set_provider_manager(original_manager)
         _reset_settings_cache()
@@ -109,8 +111,8 @@ def test_create_app_accepts_openrouter_api_key_alias(monkeypatch):
     try:
         create_app()
         available = manager.available()
-        assert "openrouter" in available
-        assert manager.default == "openrouter"
+        assert set(available) == {"mcp-agent"}
+        assert manager.default == "mcp-agent"
     finally:
         set_provider_manager(original_manager)
         _reset_settings_cache()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -40,7 +40,7 @@ from app.agents.manager import (
 
 
 class _SilentProvider:
-    name = "openrouter"
+    name = "mcp-agent"
 
     async def chat(self, messages, **options):  # type: ignore[override]
         return ChatResponse(

--- a/tests/test_settings_config_loading.py
+++ b/tests/test_settings_config_loading.py
@@ -23,7 +23,7 @@ def test_settings_load_from_default_config_when_present(monkeypatch, tmp_path):
     config_file.write_text(
         """
 openrouter_key: sk-or-config
-default_provider_name: openrouter
+default_provider_name: mcp-agent
     """.strip()
     )
 
@@ -40,7 +40,7 @@ default_provider_name: openrouter
     settings = config_module.get_settings()
 
     assert settings.openrouter_key == "sk-or-config"
-    assert settings.default_provider_name == "openrouter"
+    assert settings.default_provider_name == "mcp-agent"
 
 
 def test_settings_fall_back_to_example_config(monkeypatch, tmp_path):
@@ -51,7 +51,7 @@ def test_settings_fall_back_to_example_config(monkeypatch, tmp_path):
     example_file.write_text(
         """
 openrouter_key: sk-or-example
-default_provider_name: openrouter
+default_provider_name: mcp-agent
         """.strip()
     )
 
@@ -68,7 +68,7 @@ default_provider_name: openrouter
     settings = config_module.get_settings()
 
     assert settings.openrouter_key == "sk-or-example"
-    assert settings.default_provider_name == "openrouter"
+    assert settings.default_provider_name == "mcp-agent"
 
 
 def test_environment_overrides_config_file(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- make the MCP agent the sole registered provider and allow OpenRouter/OpenAI fallback routing based on configuration
- update configuration defaults, documentation, and agent instructions to reflect the new provider contract
- adjust unit tests and sample settings to exercise the MCP agent centric behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68fc8154ab7883258101457690a3a73b