### PR TITLE
Relocate metrics last-updated indicator to header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,9 @@ These instructions apply to the entire repository.
   backend changes.
 - Any new controls should remain aligned with the existing FastAPI endpoints so
   the file can operate as a drop-in static asset.
+
+## User-facing content guidelines
+- In HTML or any other user-visible assets (به‌جز README)، از نوشتن جملاتی که
+  به‌صورت مستقیم به آدرس یا متدهای API (مانند «داده‌های به‌دست‌آمده از
+  GET /metrics») اشاره می‌کنند، خودداری کنید. اطلاعات را به‌شکل توصیفی و
+  کاربرپسند بیان کنید.

--- a/examples/metrics.html
+++ b/examples/metrics.html
@@ -11,20 +11,30 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
     <style>
       :root {
-        color-scheme: light dark;
+        color-scheme: light;
         font-family: "Vazir", "Vazirmatn", "IRANSans", "Segoe UI", sans-serif;
         font-size: 16px;
-        --bg: #0f172a;
-        --card: rgba(15, 23, 42, 0.8);
-        --accent: #38bdf8;
-        --text: #e2e8f0;
-        --muted: #94a3b8;
+        --bg: #f1f5f9;
+        --card: #ffffff;
+        --accent: #0ea5e9;
+        --text: #0f172a;
+        --muted: #475569;
+        --border: #cbd5f5;
+        --surface: #f8fafc;
+      }
+
+      body,
+      button,
+      input,
+      select,
+      textarea {
+        font-family: inherit;
       }
 
       body {
         margin: 0;
         min-height: 100vh;
-        background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+        background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -35,11 +45,10 @@
       .container {
         width: min(1080px, 100%);
         background: var(--card);
-        border-radius: 28px;
-        box-shadow: 0 35px 70px rgba(8, 11, 24, 0.45);
+        border-radius: 24px;
+        box-shadow: 0 30px 60px rgba(148, 163, 184, 0.25);
         padding: 2.5rem 3rem;
-        border: 1px solid rgba(255, 255, 255, 0.08);
-        backdrop-filter: blur(18px);
+        border: 1px solid var(--border);
       }
 
       header {
@@ -71,19 +80,20 @@
 
       select {
         padding: 0.65rem 1.2rem;
-        border-radius: 16px;
-        border: 1px solid rgba(148, 163, 184, 0.3);
-        background: rgba(15, 23, 42, 0.6);
+        border-radius: 14px;
+        border: 1px solid var(--border);
+        background: var(--surface);
         color: var(--text);
         font-size: 1rem;
         cursor: pointer;
-        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
       }
 
       select:focus {
         outline: none;
         border-color: var(--accent);
-        box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+        box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.25);
+        background: #ffffff;
       }
 
       .stats {
@@ -94,10 +104,11 @@
       }
 
       .stat-card {
-        background: rgba(15, 23, 42, 0.6);
+        background: var(--surface);
         border-radius: 20px;
         padding: 1.5rem;
-        border: 1px solid rgba(148, 163, 184, 0.18);
+        border: 1px solid var(--border);
+        box-shadow: 0 10px 25px rgba(226, 232, 240, 0.6);
       }
 
       .stat-card h2 {
@@ -117,6 +128,11 @@
         position: relative;
         width: 100%;
         height: 420px;
+        background: var(--surface);
+        border-radius: 20px;
+        border: 1px solid var(--border);
+        padding: 1rem;
+        box-shadow: inset 0 2px 10px rgba(15, 23, 42, 0.05);
       }
 
       footer {
@@ -130,7 +146,7 @@
       }
 
       .error {
-        color: #f87171;
+        color: #b91c1c;
         font-weight: 600;
       }
     </style>
@@ -140,7 +156,7 @@
       <header>
         <div>
           <h1>نمای زنده متریک‌های سرویس</h1>
-          <p>داده‌های به‌دست‌آمده از <code>GET /metrics</code></p>
+          <p>آخرین به‌روزرسانی: <span id="lastUpdated">—</span></p>
         </div>
         <div class="controls">
           <label for="interval">بازهٔ به‌روزرسانی</label>
@@ -178,8 +194,7 @@
       </div>
 
       <footer>
-        <div>آخرین به‌روزرسانی: <span id="lastUpdated">—</span></div>
-        <div id="status"></div>
+        <div id="status" aria-live="assertive"></div>
       </footer>
     </div>
 


### PR DESCRIPTION
## Summary
- place the last-updated timestamp alongside the hero title on the metrics sample page
- keep the status area in the footer with live announcements for errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fc9f75dd308325a572b26af6916293