### PR TITLE
Limit metrics collection to chat session activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,10 @@ body:
 
 ### Structured logging & metrics
 Each request is logged with a unique `X-Request-ID`. Metrics can be harvested by
-polling `/metrics` and include aggregated counters for requests, responses, and
-errors.
+polling `/metrics` and include aggregated counters for chat activity (session
+creation and message posts), responses, and errors. Introspection endpoints such
+as `/metrics` and `/health` are intentionally excluded from the counters so the
+statistics focus solely on live conversation traffic.
 
 #### Disabling metrics collection
 Set the environment variable `METRICS_ENABLED=false` (or the equivalent setting


### PR DESCRIPTION
## Summary
- restrict the metrics middleware so only chat session creation and message posts are counted
- adjust the metrics toggle test to exercise chat traffic while avoiding external redis dependencies
- document that observability counters now focus solely on chat interactions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fca47cf7108325be66d0c1a2dbc646