### PR TITLE
Add admin UI and history APIs for chat management

### DIFF
--- a/app/admin_ui.py
+++ b/app/admin_ui.py
@@ -1,0 +1,63 @@
+"""Lightweight admin interface views rendered with Jinja templates."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
+
+router = APIRouter(prefix="/admin/ui", tags=["admin-ui"])
+
+
+@router.get("/", response_class=HTMLResponse, name="admin-ui-home")
+async def home_page(request: Request) -> HTMLResponse:
+    """Render the admin home page with quick links to tools."""
+
+    return templates.TemplateResponse(
+        "admin/home.html",
+        {"request": request, "page_id": "home"},
+    )
+
+
+@router.get("/sessions", response_class=HTMLResponse, name="admin-ui-sessions")
+async def sessions_page(request: Request) -> HTMLResponse:
+    """Render the session management dashboard."""
+
+    return templates.TemplateResponse(
+        "admin/sessions.html",
+        {"request": request, "page_id": "sessions"},
+    )
+
+
+@router.get("/metrics", response_class=HTMLResponse, name="admin-ui-metrics")
+async def metrics_page(request: Request) -> HTMLResponse:
+    """Render the in-app metrics visualisation."""
+
+    return templates.TemplateResponse(
+        "admin/metrics.html",
+        {"request": request, "page_id": "metrics"},
+    )
+
+
+@router.get("/runtime", response_class=HTMLResponse, name="admin-ui-runtime")
+async def runtime_page(request: Request) -> HTMLResponse:
+    """Render the runtime diagnostics view."""
+
+    return templates.TemplateResponse(
+        "admin/runtime.html",
+        {"request": request, "page_id": "runtime"},
+    )
+
+
+@router.get("/bypass", response_class=HTMLResponse, name="admin-ui-bypass")
+async def bypass_page(request: Request) -> HTMLResponse:
+    """Render the rate limit bypass management console."""
+
+    return templates.TemplateResponse(
+        "admin/bypass.html",
+        {"request": request, "page_id": "bypass"},
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 
 from .admin import router as admin_router
+from .admin_ui import router as admin_ui_router
 from .api import sessions_router
 from .agents.manager import ProviderNotRegisteredError
 from .agents.providers import (
@@ -269,6 +270,7 @@ def create_app() -> FastAPI:
     application.include_router(root_router)
     application.include_router(meta_router)
     application.include_router(admin_router)
+    application.include_router(admin_ui_router)
     application.include_router(sessions_router)
 
     if shutdown_callbacks:

--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -1,0 +1,399 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}پنل مدیریت سرویس{% endblock %}</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/vazir-font@30.1.0/dist/font-face.css"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Vazir", "Vazirmatn", "IRANSans", "Segoe UI", sans-serif;
+        --bg-gradient: linear-gradient(135deg, #eef2ff 0%, #f8fafc 40%, #fdf2f8 100%);
+        --surface: rgba(255, 255, 255, 0.92);
+        --surface-strong: #ffffff;
+        --surface-subtle: rgba(15, 23, 42, 0.05);
+        --border: rgba(148, 163, 184, 0.4);
+        --primary: #2563eb;
+        --primary-dark: #1d4ed8;
+        --accent: #f97316;
+        --text: #0f172a;
+        --muted: #475569;
+        --shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--bg-gradient);
+        color: var(--text);
+        display: flex;
+        flex-direction: column;
+      }
+
+      header.topbar {
+        backdrop-filter: blur(12px);
+        background: rgba(255, 255, 255, 0.88);
+        border-bottom: 1px solid var(--border);
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        padding: 1.2rem clamp(1.5rem, 5vw, 3rem);
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .brand {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+
+      .brand h1 {
+        font-size: clamp(1.4rem, 2vw, 1.9rem);
+        margin: 0;
+        color: var(--primary-dark);
+      }
+
+      .brand p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+
+      nav {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      nav a {
+        text-decoration: none;
+        color: var(--muted);
+        font-weight: 600;
+        padding: 0.55rem 1.2rem;
+        border-radius: 12px;
+        border: 1px solid transparent;
+        transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+      }
+
+      nav a:hover {
+        background: rgba(37, 99, 235, 0.08);
+        color: var(--primary-dark);
+      }
+
+      nav a.active {
+        color: var(--primary-dark);
+        border-color: rgba(37, 99, 235, 0.25);
+        background: rgba(37, 99, 235, 0.15);
+      }
+
+      .token-form {
+        display: flex;
+        align-items: flex-end;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .token-form label {
+        font-size: 0.95rem;
+        color: var(--muted);
+        font-weight: 600;
+      }
+
+      .token-controls {
+        display: flex;
+        align-items: stretch;
+        gap: 0.5rem;
+      }
+
+      .token-controls input {
+        padding: 0.6rem 0.9rem;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        background: var(--surface-subtle);
+        min-width: clamp(180px, 20vw, 260px);
+        font-family: inherit;
+        font-size: 0.95rem;
+      }
+
+      .token-controls button,
+      .token-form button[type="submit"] {
+        border: none;
+        border-radius: 12px;
+        padding: 0.6rem 1.1rem;
+        background: rgba(37, 99, 235, 0.12);
+        color: var(--primary-dark);
+        font-weight: 600;
+        font-family: inherit;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.15s ease;
+      }
+
+      .token-controls button:hover,
+      .token-form button[type="submit"]:hover {
+        background: rgba(37, 99, 235, 0.2);
+      }
+
+      .token-controls button:active,
+      .token-form button[type="submit"]:active {
+        transform: translateY(1px);
+      }
+
+      #tokenStatus {
+        width: 100%;
+        margin: 0.25rem 0 0;
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+
+      main.content {
+        flex: 1;
+        width: min(1200px, 100%);
+        margin: 2.5rem auto;
+        padding: clamp(1.5rem, 5vw, 3rem);
+        background: var(--surface);
+        border-radius: 28px;
+        border: 1px solid var(--border);
+        box-shadow: var(--shadow);
+      }
+
+      footer {
+        margin: 1.5rem auto 2.5rem;
+        text-align: center;
+        color: rgba(15, 23, 42, 0.55);
+        font-size: 0.9rem;
+      }
+
+      .grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+
+      .card {
+        background: var(--surface-strong);
+        border-radius: 20px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        padding: 1.75rem;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .card:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 22px 52px rgba(15, 23, 42, 0.12);
+      }
+
+      .card h2 {
+        margin-top: 0;
+        font-size: 1.4rem;
+        color: var(--primary);
+      }
+
+      .card p {
+        color: var(--muted);
+        line-height: 1.8;
+        font-size: 0.98rem;
+      }
+
+      .status-message {
+        margin-top: 0.75rem;
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+
+      .status-message.error {
+        color: #dc2626;
+      }
+
+      @media (max-width: 860px) {
+        header.topbar {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        nav {
+          justify-content: flex-start;
+        }
+
+        .token-controls input {
+          min-width: 0;
+          width: min(100%, 240px);
+        }
+      }
+
+      @media (max-width: 600px) {
+        main.content {
+          margin: 1.5rem auto;
+          padding: 1.5rem;
+        }
+
+        nav {
+          gap: 0.5rem;
+        }
+
+        nav a {
+          padding-inline: 1rem;
+        }
+      }
+    </style>
+  </head>
+  <body data-page="{{ page_id | default('home') }}">
+    <header class="topbar">
+      <div class="brand">
+        <h1>پنل مدیریت سرویس چت</h1>
+        <p>دسترسی سریع به ابزارهای نظارتی و عملیاتی سرویس</p>
+      </div>
+      <nav>
+        <a href="{{ request.url_for('admin-ui-home') }}" class="{% if page_id == 'home' %}active{% endif %}">خانه</a>
+        <a href="{{ request.url_for('admin-ui-sessions') }}" class="{% if page_id == 'sessions' %}active{% endif %}">سشن‌ها و گفتگوها</a>
+        <a href="{{ request.url_for('admin-ui-metrics') }}" class="{% if page_id == 'metrics' %}active{% endif %}">متریک‌ها</a>
+        <a href="{{ request.url_for('admin-ui-runtime') }}" class="{% if page_id == 'runtime' %}active{% endif %}">اطلاعات سرویس</a>
+        <a href="{{ request.url_for('admin-ui-bypass') }}" class="{% if page_id == 'bypass' %}active{% endif %}">مدیریت آی‌پی‌ها</a>
+      </nav>
+      <form class="token-form" id="tokenForm">
+        <label for="adminTokenInput">توکن ادمین</label>
+        <div class="token-controls">
+          <input id="adminTokenInput" type="password" autocomplete="off" placeholder="توکن را وارد کنید" />
+          <button type="button" id="toggleToken">نمایش</button>
+          <button type="submit">ذخیره</button>
+        </div>
+        <p id="tokenStatus"></p>
+      </form>
+    </header>
+
+    <main class="content">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer>
+      این رابط به‌صورت یکپارچه با API مدیریت کار می‌کند و برای کاربری روزمره در فضای
+      روشن طراحی شده است.
+    </footer>
+
+    <script>
+      (function () {
+        const STORAGE_KEYS = {
+          token: "admin-ui-token",
+        };
+
+        const tokenInput = document.getElementById("adminTokenInput");
+        const toggleButton = document.getElementById("toggleToken");
+        const tokenForm = document.getElementById("tokenForm");
+        const tokenStatus = document.getElementById("tokenStatus");
+
+        function withLocalStorage(callback) {
+          try {
+            callback();
+          } catch (error) {
+            console.warn("localStorage unavailable", error);
+          }
+        }
+
+        function loadToken() {
+          withLocalStorage(() => {
+            const stored = localStorage.getItem(STORAGE_KEYS.token);
+            if (stored) {
+              tokenInput.value = stored;
+              tokenStatus.textContent = "توکن از تنظیمات ذخیره‌شده بارگذاری شد.";
+            } else {
+              tokenStatus.textContent = "توکن برای درخواست‌های محافظت‌شده الزامی است.";
+            }
+          });
+        }
+
+        function persistToken(value) {
+          withLocalStorage(() => {
+            if (value) {
+              localStorage.setItem(STORAGE_KEYS.token, value);
+            } else {
+              localStorage.removeItem(STORAGE_KEYS.token);
+            }
+          });
+        }
+
+        function showStatus(message, isError = false) {
+          if (!tokenStatus) return;
+          tokenStatus.textContent = message;
+          tokenStatus.classList.toggle("error", Boolean(isError));
+        }
+
+        loadToken();
+
+        if (toggleButton) {
+          toggleButton.addEventListener("click", () => {
+            const isPassword = tokenInput.type === "password";
+            tokenInput.type = isPassword ? "text" : "password";
+            toggleButton.textContent = isPassword ? "مخفی کردن" : "نمایش";
+          });
+        }
+
+        if (tokenForm) {
+          tokenForm.addEventListener("submit", (event) => {
+            event.preventDefault();
+            const trimmed = tokenInput.value.trim();
+            persistToken(trimmed);
+            showStatus(trimmed ? "توکن ذخیره شد و در درخواست‌ها استفاده می‌شود." : "توکن پاک شد.");
+          });
+        }
+
+        function getToken() {
+          return tokenInput.value.trim();
+        }
+
+        async function adminFetch(path, options = {}) {
+          const normalisedPath = path.startsWith("/") ? path : `/${path}`;
+          const headers = new Headers(options.headers || {});
+          const token = getToken();
+          if (token) {
+            headers.set("X-Admin-Token", token);
+          }
+          if (!headers.has("Content-Type") && options.method && options.method !== "GET") {
+            headers.set("Content-Type", "application/json");
+          }
+          const response = await fetch(normalisedPath, {
+            ...options,
+            headers,
+          });
+          if (!response.ok) {
+            let detail = `${response.status} ${response.statusText}`;
+            try {
+              const data = await response.json();
+              if (data && data.message) {
+                detail = data.message;
+              }
+            } catch (error) {
+              /* non JSON response */
+            }
+            throw new Error(detail);
+          }
+          if (response.status === 204) {
+            return null;
+          }
+          const text = await response.text();
+          return text ? JSON.parse(text) : null;
+        }
+
+        window.AdminUI = {
+          adminFetch,
+          getToken,
+          showStatus,
+        };
+      })();
+    </script>
+
+    {% block extra_js %}{% endblock %}
+  </body>
+</html>

--- a/app/templates/admin/bypass.html
+++ b/app/templates/admin/bypass.html
@@ -1,0 +1,313 @@
+{% extends "admin/base.html" %}
+
+{% block title %}مدیریت آی‌پی‌های مجاز{% endblock %}
+
+{% block content %}
+  <h2>مدیریت آی‌پی‌های دارای دسترسی ویژه</h2>
+  <p>
+    این صفحه امکان مشاهده، جستجو و به‌روزرسانی فهرست آی‌پی‌هایی را که از محدودیت نرخ عبور داده
+    شده‌اند فراهم می‌کند. ابتدا تنظیمات اتصال را در بالای صفحه انجام دهید و سپس از دکمه «دریافت
+    لیست» استفاده کنید.
+  </p>
+
+  <section class="grid">
+    <article class="card">
+      <h2>فهرست آی‌پی‌ها</h2>
+      <div class="toolbar">
+        <input id="searchInput" type="search" placeholder="جستجو در فهرست" />
+        <div class="toolbar-actions">
+          <button type="button" class="secondary" id="copyBtn">کپی لیست</button>
+          <button type="button" class="secondary" id="exportBtn">دانلود JSON</button>
+          <button type="button" class="primary" id="fetchBtn">دریافت لیست</button>
+        </div>
+      </div>
+      <p class="status-message" id="fetchStatus"></p>
+      <p class="meta" id="countInfo"></p>
+      <ul id="ipList" class="ip-list"></ul>
+    </article>
+
+    <article class="card">
+      <h2>افزودن آی‌پی جدید</h2>
+      <form id="addForm" class="stack-form">
+        <label for="ipInput">آی‌پی مورد نظر</label>
+        <input id="ipInput" type="text" placeholder="مثال: 203.0.113.24" required />
+        <button type="submit" class="primary">افزودن</button>
+      </form>
+      <p class="status-message" id="addStatus"></p>
+    </article>
+
+    <article class="card">
+      <h2>افزودن گروهی</h2>
+      <form id="bulkForm" class="stack-form">
+        <label for="bulkInput">آی‌پی‌ها را خط به خط وارد کنید</label>
+        <textarea
+          id="bulkInput"
+          placeholder="مثال:\n192.0.2.1\n198.51.100.25"
+          rows="6"
+        ></textarea>
+        <button type="submit" class="primary">ارسال آی‌پی‌ها</button>
+      </form>
+      <p class="status-message" id="bulkStatus"></p>
+    </article>
+  </section>
+{% endblock %}
+
+{% block extra_js %}
+  <style>
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+      margin-bottom: 1rem;
+    }
+
+    .toolbar input[type="search"] {
+      flex: 1;
+      min-width: 200px;
+      padding: 0.65rem 0.9rem;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.92);
+      font-family: inherit;
+    }
+
+    .toolbar-actions {
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+    }
+
+    .ip-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      max-height: 340px;
+      overflow-y: auto;
+    }
+
+    .ip-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.8rem 1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: #f8fbff;
+    }
+
+    .ip-item span {
+      flex: 1;
+      word-break: break-word;
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .ip-item button {
+      border: none;
+      border-radius: 10px;
+      padding: 0.45rem 1rem;
+      background: rgba(239, 68, 68, 0.12);
+      color: #b91c1c;
+      cursor: pointer;
+      font-family: inherit;
+      font-weight: 600;
+    }
+
+    .meta {
+      color: var(--muted);
+      font-size: 0.92rem;
+      margin-top: 0.5rem;
+    }
+
+    .stack-form {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+  </style>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const ipListElement = document.getElementById("ipList");
+      const fetchBtn = document.getElementById("fetchBtn");
+      const fetchStatus = document.getElementById("fetchStatus");
+      const countInfo = document.getElementById("countInfo");
+      const searchInput = document.getElementById("searchInput");
+      const copyBtn = document.getElementById("copyBtn");
+      const exportBtn = document.getElementById("exportBtn");
+      const addForm = document.getElementById("addForm");
+      const addStatus = document.getElementById("addStatus");
+      const bulkForm = document.getElementById("bulkForm");
+      const bulkStatus = document.getElementById("bulkStatus");
+      const bulkInput = document.getElementById("bulkInput");
+
+      let cachedIps = [];
+
+      function setStatus(element, message, isError = false) {
+        element.textContent = message;
+        element.classList.toggle("error", Boolean(isError));
+      }
+
+      function renderList(filterValue = "") {
+        ipListElement.innerHTML = "";
+        const normalised = filterValue.trim().toLowerCase();
+        const items = normalised
+          ? cachedIps.filter((ip) => ip.toLowerCase().includes(normalised))
+          : [...cachedIps];
+
+        if (!items.length) {
+          const empty = document.createElement("li");
+          empty.textContent = normalised ? "آی‌پی مطابق با جستجو یافت نشد." : "آی‌پی ثبت نشده است.";
+          empty.style.textAlign = "center";
+          empty.style.opacity = "0.7";
+          ipListElement.appendChild(empty);
+          countInfo.textContent = "";
+          return;
+        }
+
+        items.forEach((ip) => {
+          const item = document.createElement("li");
+          item.className = "ip-item";
+          const label = document.createElement("span");
+          label.textContent = ip;
+          const removeBtn = document.createElement("button");
+          removeBtn.type = "button";
+          removeBtn.textContent = "حذف";
+          removeBtn.addEventListener("click", () => removeIp(ip));
+          item.append(label, removeBtn);
+          ipListElement.appendChild(item);
+        });
+
+        countInfo.textContent = normalised
+          ? `نمایش ${items.length} مورد از ${cachedIps.length}`
+          : `تعداد کل آی‌پی‌ها: ${cachedIps.length}`;
+      }
+
+      async function refreshList() {
+        setStatus(fetchStatus, "در حال دریافت...");
+        try {
+          const ips = await AdminUI.adminFetch("/admin/bypass");
+          cachedIps = Array.isArray(ips) ? ips : [];
+          setStatus(fetchStatus, "لیست با موفقیت دریافت شد.");
+          renderList(searchInput.value || "");
+        } catch (error) {
+          cachedIps = [];
+          ipListElement.innerHTML = "";
+          countInfo.textContent = "";
+          setStatus(fetchStatus, error.message, true);
+        }
+      }
+
+      async function removeIp(ip) {
+        setStatus(fetchStatus, `در حال حذف ${ip}...`);
+        try {
+          await AdminUI.adminFetch(`/admin/bypass/${encodeURIComponent(ip)}`, {
+            method: "DELETE",
+          });
+          cachedIps = cachedIps.filter((item) => item !== ip);
+          setStatus(fetchStatus, "آی‌پی حذف شد.");
+          renderList(searchInput.value || "");
+        } catch (error) {
+          setStatus(fetchStatus, error.message, true);
+        }
+      }
+
+      addForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const input = document.getElementById("ipInput");
+        const ip = input.value.trim();
+        if (!ip) {
+          setStatus(addStatus, "لطفاً آی‌پی را وارد کنید.", true);
+          return;
+        }
+        setStatus(addStatus, "در حال ثبت آی‌پی...");
+        try {
+          const response = await AdminUI.adminFetch("/admin/bypass", {
+            method: "POST",
+            body: JSON.stringify({ ip }),
+          });
+          input.value = "";
+          const normalised = response && response.ip ? response.ip : ip;
+          cachedIps.push(normalised);
+          cachedIps = Array.from(new Set(cachedIps));
+          setStatus(addStatus, "آی‌پی با موفقیت افزوده شد.");
+          renderList(searchInput.value || "");
+        } catch (error) {
+          setStatus(addStatus, error.message, true);
+        }
+      });
+
+      bulkForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const lines = bulkInput.value
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean);
+        if (!lines.length) {
+          setStatus(bulkStatus, "هیچ آی‌پی‌ای برای افزودن وجود ندارد.", true);
+          return;
+        }
+        setStatus(bulkStatus, "در حال ارسال آی‌پی‌ها...");
+        const unique = Array.from(new Set(lines));
+        for (const ip of unique) {
+          try {
+            const response = await AdminUI.adminFetch("/admin/bypass", {
+              method: "POST",
+              body: JSON.stringify({ ip }),
+            });
+            const normalised = response && response.ip ? response.ip : ip;
+            cachedIps.push(normalised);
+          } catch (error) {
+            console.warn("bulk add failed", ip, error);
+          }
+        }
+        cachedIps = Array.from(new Set(cachedIps));
+        setStatus(bulkStatus, "فرآیند افزودن به پایان رسید.");
+        bulkInput.value = "";
+        renderList(searchInput.value || "");
+      });
+
+      searchInput.addEventListener("input", (event) => {
+        renderList(event.target.value || "");
+      });
+
+      copyBtn.addEventListener("click", async () => {
+        if (!cachedIps.length) {
+          setStatus(fetchStatus, "آی‌پی‌ای برای کپی وجود ندارد.", true);
+          return;
+        }
+        try {
+          await navigator.clipboard.writeText(cachedIps.join("\n"));
+          setStatus(fetchStatus, "لیست در کلیپ‌بورد ذخیره شد.");
+        } catch (error) {
+          setStatus(fetchStatus, "امکان دسترسی به کلیپ‌بورد وجود ندارد.", true);
+        }
+      });
+
+      exportBtn.addEventListener("click", () => {
+        if (!cachedIps.length) {
+          setStatus(fetchStatus, "آی‌پی‌ای برای دانلود وجود ندارد.", true);
+          return;
+        }
+        const blob = new Blob([JSON.stringify(cachedIps, null, 2)], {
+          type: "application/json;charset=utf-8",
+        });
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement("a");
+        anchor.href = url;
+        anchor.download = `bypass-ips-${Date.now()}.json`;
+        anchor.click();
+        URL.revokeObjectURL(url);
+        setStatus(fetchStatus, "فایل JSON آماده شد.");
+      });
+
+      fetchBtn.addEventListener("click", refreshList);
+      refreshList();
+    });
+  </script>
+{% endblock %}

--- a/app/templates/admin/home.html
+++ b/app/templates/admin/home.html
@@ -1,0 +1,61 @@
+{% extends "admin/base.html" %}
+
+{% block title %}نمای کلی پنل مدیریت{% endblock %}
+
+{% block content %}
+  <section class="grid">
+    <article class="card">
+      <h2>سشن‌ها و گفتگوها</h2>
+      <p>
+        مشاهده‌ی سشن‌های فعال و آرشیوشده به همراه جزئیات پیام‌ها برای پایش دقیق عملیات. این بخش
+        برای تیم پشتیبانی فراهم شده تا بتوانند وضعیت ذخیره‌سازی را نیز بررسی کنند.
+      </p>
+      <a class="nav-button" href="{{ request.url_for('admin-ui-sessions') }}">ورود به مدیریت سشن</a>
+    </article>
+    <article class="card">
+      <h2>متریک‌های زنده</h2>
+      <p>
+        تصویری لحظه‌ای از درخواست‌ها، پاسخ‌ها و میانگین زمان پردازش را مشاهده کنید. نمودارها
+        به‌صورت زنده به‌روزرسانی شده و به تشخیص سریع مشکلات کمک می‌کنند.
+      </p>
+      <a class="nav-button" href="{{ request.url_for('admin-ui-metrics') }}">مشاهده متریک‌ها</a>
+    </article>
+    <article class="card">
+      <h2>اطلاعات سرویس</h2>
+      <p>
+        وضعیت فعلی ارائه‌دهندگان، تنظیمات حافظه و جزئیات فعال‌سازی MCP در این قسمت قابل مشاهده است.
+        برای عیب‌یابی سریع بسیار کاربردی است.
+      </p>
+      <a class="nav-button" href="{{ request.url_for('admin-ui-runtime') }}">وضعیت سرویس</a>
+    </article>
+    <article class="card">
+      <h2>مدیریت آی‌پی‌های مجاز</h2>
+      <p>
+        فهرست آی‌پی‌های دارای دسترسی ویژه را به‌سادگی مدیریت کنید، آی‌پی جدید اضافه کرده یا موارد
+        قدیمی را حذف کنید. امکان برون‌بری و جستجوی سریع نیز فراهم است.
+      </p>
+      <a class="nav-button" href="{{ request.url_for('admin-ui-bypass') }}">تنظیم آی‌پی‌ها</a>
+    </article>
+  </section>
+{% endblock %}
+
+{% block extra_js %}
+  <style>
+    .nav-button {
+      display: inline-flex;
+      margin-top: 1.25rem;
+      padding: 0.7rem 1.5rem;
+      border-radius: 14px;
+      background: linear-gradient(135deg, var(--primary), #3b82f6);
+      color: #fff;
+      text-decoration: none;
+      font-weight: 600;
+      transition: transform 0.15s ease, box-shadow 0.2s ease;
+    }
+
+    .nav-button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 32px rgba(37, 99, 235, 0.35);
+    }
+  </style>
+{% endblock %}

--- a/app/templates/admin/metrics.html
+++ b/app/templates/admin/metrics.html
@@ -1,0 +1,274 @@
+{% extends "admin/base.html" %}
+
+{% block title %}نمای زنده متریک‌ها{% endblock %}
+
+{% block content %}
+  <section class="metrics-header">
+    <div>
+      <h2>نمای زنده متریک‌های سرویس</h2>
+      <p>
+        آخرین وضعیت درخواست‌ها و پاسخ‌ها در این بخش به‌صورت نمودار زنده نمایش داده می‌شود. برای
+        دسترسی دقیق‌تر می‌توانید بازهٔ به‌روزرسانی را تغییر دهید.
+      </p>
+      <p>آخرین به‌روزرسانی: <strong id="lastUpdated">—</strong></p>
+    </div>
+    <div class="interval-control">
+      <label for="intervalSelect">بازهٔ به‌روزرسانی</label>
+      <select id="intervalSelect">
+        <option value="5000">۵ ثانیه</option>
+        <option value="10000">۱۰ ثانیه</option>
+        <option value="20000" selected>۲۰ ثانیه</option>
+        <option value="30000">۳۰ ثانیه</option>
+        <option value="60000">۶۰ ثانیه</option>
+      </select>
+    </div>
+  </section>
+
+  <section class="stats" aria-live="polite">
+    <div class="stat-card">
+      <h3>تعداد کل درخواست‌ها</h3>
+      <p id="requestsTotal">۰</p>
+    </div>
+    <div class="stat-card">
+      <h3>تعداد کل پاسخ‌ها</h3>
+      <p id="responsesTotal">۰</p>
+    </div>
+    <div class="stat-card">
+      <h3>تعداد خطاها</h3>
+      <p id="errorsTotal">۰</p>
+    </div>
+    <div class="stat-card">
+      <h3>میانگین تأخیر (میلی‌ثانیه)</h3>
+      <p id="latencyAvg">۰</p>
+    </div>
+  </section>
+
+  <div class="chart-wrapper">
+    <canvas id="metricsChart" aria-label="نمودار روند درخواست‌ها" role="img"></canvas>
+  </div>
+  <p class="status-message" id="metricsStatus"></p>
+{% endblock %}
+
+{% block extra_js %}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
+  <style>
+    .metrics-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+    }
+
+    .metrics-header h2 {
+      margin: 0 0 0.75rem;
+      font-size: 1.6rem;
+      color: var(--primary-dark);
+    }
+
+    .metrics-header p {
+      margin: 0 0 0.5rem;
+      color: var(--muted);
+      line-height: 1.8;
+    }
+
+    .interval-control {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      min-width: 160px;
+    }
+
+    .interval-control label {
+      font-weight: 600;
+      color: var(--muted);
+    }
+
+    .interval-control select {
+      padding: 0.6rem 1rem;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.85);
+      font-family: inherit;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1.2rem;
+      margin-top: 2rem;
+    }
+
+    .stat-card {
+      background: rgba(255, 255, 255, 0.9);
+      border-radius: 18px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      padding: 1.5rem;
+      box-shadow: 0 16px 35px rgba(15, 23, 42, 0.08);
+    }
+
+    .stat-card h3 {
+      margin: 0 0 0.5rem;
+      font-size: 1.05rem;
+      color: var(--muted);
+    }
+
+    .stat-card p {
+      margin: 0;
+      font-size: 1.7rem;
+      font-weight: 700;
+      color: var(--primary-dark);
+    }
+
+    .chart-wrapper {
+      margin-top: 2.5rem;
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: 20px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      padding: 1rem;
+      box-shadow: inset 0 3px 18px rgba(15, 23, 42, 0.06);
+    }
+
+    .status-message {
+      margin-top: 1rem;
+    }
+  </style>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const requestsTotal = document.getElementById("requestsTotal");
+      const responsesTotal = document.getElementById("responsesTotal");
+      const errorsTotal = document.getElementById("errorsTotal");
+      const latencyAvg = document.getElementById("latencyAvg");
+      const lastUpdated = document.getElementById("lastUpdated");
+      const intervalSelect = document.getElementById("intervalSelect");
+      const statusMessage = document.getElementById("metricsStatus");
+      const ctx = document.getElementById("metricsChart");
+
+      const dataPoints = {
+        labels: [],
+        requests: [],
+        responses: [],
+        errors: [],
+      };
+
+      const chart = new Chart(ctx, {
+        type: "line",
+        data: {
+          labels: dataPoints.labels,
+          datasets: [
+            {
+              label: "درخواست‌ها",
+              data: dataPoints.requests,
+              borderColor: "#2563eb",
+              backgroundColor: "rgba(37, 99, 235, 0.15)",
+              tension: 0.35,
+              fill: true,
+            },
+            {
+              label: "پاسخ‌ها",
+              data: dataPoints.responses,
+              borderColor: "#22c55e",
+              backgroundColor: "rgba(34, 197, 94, 0.18)",
+              tension: 0.35,
+              fill: true,
+            },
+            {
+              label: "خطاها",
+              data: dataPoints.errors,
+              borderColor: "#f97316",
+              backgroundColor: "rgba(249, 115, 22, 0.18)",
+              tension: 0.35,
+              fill: true,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              labels: {
+                font: { family: "Vazir", size: 12 },
+              },
+            },
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              ticks: {
+                font: { family: "Vazir" },
+              },
+            },
+            x: {
+              ticks: {
+                font: { family: "Vazir" },
+              },
+            },
+          },
+        },
+      });
+
+      let timer = null;
+
+      function setStatus(message, isError = false) {
+        statusMessage.textContent = message;
+        statusMessage.classList.toggle("error", Boolean(isError));
+      }
+
+      function scheduleNext(interval) {
+        if (timer) {
+          clearTimeout(timer);
+        }
+        timer = setTimeout(fetchMetrics, interval);
+      }
+
+      function updateChart(snapshot) {
+        const timestamp = new Date().toLocaleTimeString("fa-IR", {
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        });
+        dataPoints.labels.push(timestamp);
+        dataPoints.requests.push(snapshot.requests_total);
+        dataPoints.responses.push(snapshot.responses_total);
+        dataPoints.errors.push(snapshot.errors_total);
+        if (dataPoints.labels.length > 15) {
+          dataPoints.labels.shift();
+          dataPoints.requests.shift();
+          dataPoints.responses.shift();
+          dataPoints.errors.shift();
+        }
+        chart.update();
+      }
+
+      async function fetchMetrics() {
+        const interval = Number(intervalSelect.value || 20000);
+        try {
+          const snapshot = await AdminUI.adminFetch("/metrics");
+          requestsTotal.textContent = snapshot.requests_total.toLocaleString("fa-IR");
+          responsesTotal.textContent = snapshot.responses_total.toLocaleString("fa-IR");
+          errorsTotal.textContent = snapshot.errors_total.toLocaleString("fa-IR");
+          latencyAvg.textContent = snapshot.request_latency_avg_ms.toLocaleString("fa-IR", {
+            maximumFractionDigits: 2,
+          });
+          lastUpdated.textContent = new Date().toLocaleString("fa-IR");
+          setStatus("اطلاعات با موفقیت به‌روزرسانی شد.");
+          updateChart(snapshot);
+        } catch (error) {
+          setStatus(error.message, true);
+        } finally {
+          scheduleNext(interval);
+        }
+      }
+
+      intervalSelect.addEventListener("change", () => {
+        fetchMetrics();
+      });
+
+      fetchMetrics();
+    });
+  </script>
+{% endblock %}

--- a/app/templates/admin/runtime.html
+++ b/app/templates/admin/runtime.html
@@ -1,0 +1,76 @@
+{% extends "admin/base.html" %}
+
+{% block title %}اطلاعات سرویس{% endblock %}
+
+{% block content %}
+  <h2>نمای کلی پیکربندی سرویس</h2>
+  <p>
+    در این بخش خلاصه‌ای از پیکربندی فعلی سرویس شامل اطلاعات ارائه‌دهندگان، حافظهٔ گفتگو و وضعیت
+    فعال‌سازی MCP نمایش داده می‌شود. این اطلاعات برای عیب‌یابی سریع و تطبیق تنظیمات مفید است.
+  </p>
+
+  <section class="grid">
+    <article class="card runtime-card">
+      <div class="header">
+        <h2>وضعیت پیکربندی</h2>
+        <button type="button" class="primary" id="refreshRuntime">به‌روزرسانی</button>
+      </div>
+      <p class="status-message" id="runtimeStatus"></p>
+      <pre id="runtimeOutput" class="runtime-output" aria-live="polite">برای مشاهده اطلاعات روی «به‌روزرسانی» کلیک کنید.</pre>
+    </article>
+  </section>
+{% endblock %}
+
+{% block extra_js %}
+  <style>
+    .runtime-card .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    .runtime-output {
+      background: #f8fafc;
+      border-radius: 16px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      padding: 1rem;
+      min-height: 320px;
+      direction: ltr;
+      text-align: left;
+      overflow-x: auto;
+      font-family: "SFMono-Regular", "Consolas", "Courier New", monospace;
+      font-size: 0.92rem;
+      white-space: pre-wrap;
+    }
+  </style>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const refreshButton = document.getElementById("refreshRuntime");
+      const statusElement = document.getElementById("runtimeStatus");
+      const outputElement = document.getElementById("runtimeOutput");
+
+      function setStatus(message, isError = false) {
+        statusElement.textContent = message;
+        statusElement.classList.toggle("error", Boolean(isError));
+      }
+
+      async function fetchRuntime() {
+        setStatus("در حال دریافت اطلاعات...");
+        try {
+          const payload = await AdminUI.adminFetch("/admin/runtime");
+          outputElement.textContent = JSON.stringify(payload, null, 2);
+          setStatus("اطلاعات با موفقیت به‌روزرسانی شد.");
+        } catch (error) {
+          outputElement.textContent = "مشکلی در دریافت اطلاعات رخ داد.";
+          setStatus(error.message, true);
+        }
+      }
+
+      refreshButton.addEventListener("click", fetchRuntime);
+      fetchRuntime();
+    });
+  </script>
+{% endblock %}

--- a/app/templates/admin/sessions.html
+++ b/app/templates/admin/sessions.html
@@ -1,0 +1,415 @@
+{% extends "admin/base.html" %}
+
+{% block title %}مدیریت سشن‌ها و گفتگوها{% endblock %}
+
+{% block content %}
+  <h2>بررسی سشن‌ها</h2>
+  <p>
+    این صفحه امکان مشاهده‌ی سشن‌های فعال و گفت‌وگوهای ذخیره‌شده را فراهم می‌کند. برای هر سشن،
+    می‌توانید پیام‌های جاری یا آرشیوشده را مشاهده کنید و از وضعیت ذخیره‌سازی مطمئن شوید.
+  </p>
+
+  <section class="sessions-grid">
+    <article class="card">
+      <div class="header">
+        <h2>سشن‌های فعال</h2>
+        <button type="button" class="primary" id="refreshActive">به‌روزرسانی</button>
+      </div>
+      <p class="status-message" id="activeStatus"></p>
+      <ul class="session-list" id="activeSessions"></ul>
+      <div class="transcript" id="activeTranscript">
+        <h3>جزئیات گفتگو</h3>
+        <div class="message-container" id="activeMessages"></div>
+      </div>
+    </article>
+
+    <article class="card">
+      <div class="header">
+        <h2>گفتگوهای ذخیره‌شده</h2>
+        <div class="history-controls">
+          <button type="button" class="secondary" id="prevHistory">قبلی</button>
+          <span id="historyPage">صفحه ۱</span>
+          <button type="button" class="secondary" id="nextHistory">بعدی</button>
+          <button type="button" class="primary" id="refreshHistory">بارگیری دوباره</button>
+        </div>
+      </div>
+      <p class="status-message" id="historyStatus"></p>
+      <ul class="session-list" id="historySessions"></ul>
+      <div class="transcript" id="historyTranscript">
+        <h3>پیام‌های ذخیره‌شده</h3>
+        <div class="message-container" id="historyMessages"></div>
+      </div>
+    </article>
+  </section>
+{% endblock %}
+
+{% block extra_js %}
+  <style>
+    .sessions-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 1.8rem;
+      margin-top: 2rem;
+    }
+
+    .card .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .card .header h2 {
+      margin: 0;
+      font-size: 1.35rem;
+      color: var(--primary);
+    }
+
+    .primary,
+    .secondary {
+      border: none;
+      border-radius: 12px;
+      padding: 0.55rem 1.2rem;
+      font-weight: 600;
+      cursor: pointer;
+      font-family: inherit;
+      transition: transform 0.15s ease, box-shadow 0.2s ease;
+    }
+
+    .primary {
+      background: linear-gradient(135deg, var(--primary), #3b82f6);
+      color: #fff;
+      box-shadow: 0 12px 24px rgba(37, 99, 235, 0.28);
+    }
+
+    .primary:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 32px rgba(37, 99, 235, 0.32);
+    }
+
+    .secondary {
+      background: rgba(37, 99, 235, 0.08);
+      color: var(--primary-dark);
+      border: 1px solid rgba(37, 99, 235, 0.2);
+    }
+
+    .secondary:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+
+    .session-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      max-height: 360px;
+      overflow-y: auto;
+    }
+
+    .session-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.85rem 1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: #f8fbff;
+      cursor: pointer;
+      transition: transform 0.15s ease, background 0.2s ease;
+    }
+
+    .session-item.active {
+      border-color: rgba(37, 99, 235, 0.4);
+      background: rgba(37, 99, 235, 0.12);
+    }
+
+    .session-item:hover {
+      transform: translateY(-1px);
+      background: rgba(37, 99, 235, 0.08);
+    }
+
+    .session-meta {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .session-meta strong {
+      font-size: 1rem;
+      color: var(--primary-dark);
+    }
+
+    .session-meta span {
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .transcript {
+      margin-top: 1.5rem;
+      border-radius: 16px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: #ffffff;
+      padding: 1.25rem;
+      max-height: 400px;
+      overflow: hidden;
+      display: none;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .transcript.active {
+      display: flex;
+    }
+
+    .transcript h3 {
+      margin: 0;
+      font-size: 1.1rem;
+      color: var(--primary-dark);
+    }
+
+    .message-container {
+      overflow-y: auto;
+      max-height: 320px;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .message {
+      border-radius: 12px;
+      padding: 0.85rem 1rem;
+      line-height: 1.7;
+      font-size: 0.95rem;
+    }
+
+    .message.user {
+      background: rgba(37, 99, 235, 0.1);
+      align-self: flex-start;
+    }
+
+    .message.assistant {
+      background: rgba(249, 115, 22, 0.12);
+      align-self: flex-end;
+    }
+
+    .message.system {
+      background: rgba(15, 23, 42, 0.08);
+    }
+
+    .message .meta {
+      font-size: 0.82rem;
+      color: var(--muted);
+      margin-bottom: 0.4rem;
+      display: block;
+    }
+
+    .history-controls {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+    }
+  </style>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const activeList = document.getElementById("activeSessions");
+      const historyList = document.getElementById("historySessions");
+      const activeStatus = document.getElementById("activeStatus");
+      const historyStatus = document.getElementById("historyStatus");
+      const activeMessages = document.getElementById("activeMessages");
+      const historyMessages = document.getElementById("historyMessages");
+      const activeTranscript = document.getElementById("activeTranscript");
+      const historyTranscript = document.getElementById("historyTranscript");
+      const refreshActiveBtn = document.getElementById("refreshActive");
+      const refreshHistoryBtn = document.getElementById("refreshHistory");
+      const prevHistoryBtn = document.getElementById("prevHistory");
+      const nextHistoryBtn = document.getElementById("nextHistory");
+      const historyPage = document.getElementById("historyPage");
+
+      const HISTORY_LIMIT = 10;
+      let historyOffset = 0;
+      let lastHistoryCount = 0;
+
+      function setStatus(element, message, isError = false) {
+        if (!element) return;
+        element.textContent = message;
+        element.classList.toggle("error", Boolean(isError));
+      }
+
+      function formatDate(value) {
+        try {
+          return new Date(value).toLocaleString("fa-IR");
+        } catch (error) {
+          return value;
+        }
+      }
+
+      function renderMessages(container, messages) {
+        container.innerHTML = "";
+        if (!messages.length) {
+          const empty = document.createElement("p");
+          empty.textContent = "پیامی برای نمایش وجود ندارد.";
+          empty.style.opacity = "0.7";
+          container.appendChild(empty);
+          return;
+        }
+        messages.forEach((message) => {
+          const wrapper = document.createElement("div");
+          wrapper.className = `message ${message.role}`;
+          const meta = document.createElement("span");
+          meta.className = "meta";
+          if (message.stored_at) {
+            meta.textContent = `نقش: ${message.role} • ذخیره شده: ${formatDate(message.stored_at)}`;
+          } else {
+            meta.textContent = `نقش: ${message.role} • زمان: ${formatDate(message.created_at)}`;
+          }
+          const content = document.createElement("div");
+          content.textContent = message.content;
+          wrapper.append(meta, content);
+          container.appendChild(wrapper);
+        });
+      }
+
+      function activateTranscript(section) {
+        section.classList.add("active");
+      }
+
+      function clearActiveState(list) {
+        list.querySelectorAll(".session-item").forEach((item) =>
+          item.classList.remove("active")
+        );
+      }
+
+      async function loadActiveSessions() {
+        setStatus(activeStatus, "در حال دریافت...");
+        activeList.innerHTML = "";
+        activeMessages.innerHTML = "";
+        activeTranscript.classList.remove("active");
+        try {
+          const sessions = await AdminUI.adminFetch("/admin/sessions");
+          if (!sessions.length) {
+            setStatus(activeStatus, "سشن فعالی ثبت نشده است.");
+            return;
+          }
+          setStatus(activeStatus, `تعداد سشن‌های فعال: ${sessions.length}`);
+          sessions.forEach((session) => {
+            const item = document.createElement("li");
+            item.className = "session-item";
+            item.dataset.id = session.id;
+            const meta = document.createElement("div");
+            meta.className = "session-meta";
+            meta.innerHTML = `
+              <strong>${session.id}</strong>
+              <span>ایجاد شده: ${formatDate(session.created_at)}</span>
+              <span>ارائه‌دهنده: ${session.provider || "-"}</span>
+            `;
+            item.appendChild(meta);
+            item.addEventListener("click", async () => {
+              clearActiveState(activeList);
+              item.classList.add("active");
+              setStatus(activeStatus, "در حال دریافت پیام‌ها...");
+              try {
+                const messages = await AdminUI.adminFetch(
+                  `/admin/sessions/${session.id}/messages`
+                );
+                renderMessages(activeMessages, messages);
+                activateTranscript(activeTranscript);
+                setStatus(activeStatus, `تعداد پیام‌های نمایش داده شده: ${messages.length}`);
+              } catch (error) {
+                renderMessages(activeMessages, []);
+                setStatus(activeStatus, error.message, true);
+              }
+            });
+            activeList.appendChild(item);
+          });
+        } catch (error) {
+          setStatus(activeStatus, error.message, true);
+        }
+      }
+
+      async function loadHistorySessions() {
+        setStatus(historyStatus, "در حال دریافت...");
+        historyList.innerHTML = "";
+        historyMessages.innerHTML = "";
+        historyTranscript.classList.remove("active");
+        try {
+          const payload = await AdminUI.adminFetch(
+            `/admin/history/sessions?limit=${HISTORY_LIMIT}&offset=${historyOffset}`
+          );
+          lastHistoryCount = payload.sessions.length;
+          historyPage.textContent = `صفحه ${historyOffset / HISTORY_LIMIT + 1}`;
+          prevHistoryBtn.disabled = historyOffset === 0;
+          nextHistoryBtn.disabled = lastHistoryCount < HISTORY_LIMIT;
+
+          if (!payload.sessions.length) {
+            if (historyOffset === 0) {
+              setStatus(historyStatus, "هنوز گفت‌وگوی ذخیره‌شده‌ای ثبت نشده است.");
+            } else {
+              setStatus(historyStatus, "نتیجه‌ای برای این صفحه وجود ندارد.");
+            }
+            return;
+          }
+
+          setStatus(historyStatus, `تعداد نتایج این صفحه: ${payload.sessions.length}`);
+
+          payload.sessions.forEach((session) => {
+            const item = document.createElement("li");
+            item.className = "session-item";
+            item.dataset.id = session.id;
+            const meta = document.createElement("div");
+            meta.className = "session-meta";
+            meta.innerHTML = `
+              <strong>${session.id}</strong>
+              <span>زمان ذخیره: ${formatDate(session.created_at)}</span>
+              <span>ارائه‌دهنده: ${session.provider || "-"}</span>
+            `;
+            item.appendChild(meta);
+            item.addEventListener("click", async () => {
+              clearActiveState(historyList);
+              item.classList.add("active");
+              setStatus(historyStatus, "در حال دریافت پیام‌های ذخیره‌شده...");
+              try {
+                const messages = await AdminUI.adminFetch(
+                  `/admin/history/sessions/${session.id}/messages?limit=100`
+                );
+                renderMessages(historyMessages, messages.messages);
+                activateTranscript(historyTranscript);
+                setStatus(historyStatus, `تعداد پیام‌ها: ${messages.messages.length}`);
+              } catch (error) {
+                renderMessages(historyMessages, []);
+                setStatus(historyStatus, error.message, true);
+              }
+            });
+            historyList.appendChild(item);
+          });
+        } catch (error) {
+          setStatus(historyStatus, error.message, true);
+          prevHistoryBtn.disabled = historyOffset === 0;
+          nextHistoryBtn.disabled = true;
+        }
+      }
+
+      refreshActiveBtn.addEventListener("click", loadActiveSessions);
+      refreshHistoryBtn.addEventListener("click", loadHistorySessions);
+      prevHistoryBtn.addEventListener("click", () => {
+        if (historyOffset === 0) return;
+        historyOffset = Math.max(historyOffset - HISTORY_LIMIT, 0);
+        loadHistorySessions();
+      });
+      nextHistoryBtn.addEventListener("click", () => {
+        if (lastHistoryCount < HISTORY_LIMIT) return;
+        historyOffset += HISTORY_LIMIT;
+        loadHistorySessions();
+      });
+
+      loadActiveSessions();
+      loadHistorySessions();
+    });
+  </script>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest==8.3.3
 pytest-asyncio==0.21.1
 aiomysql==0.2.0
 motor==3.6.0
+jinja2==3.1.4


### PR DESCRIPTION
## Summary
- add retrievable session and message types to the history stores so persisted transcripts can be listed and fetched through the API
- extend the admin API with endpoints for active sessions, persisted history, and in-memory transcripts
- build a Jinja-based admin console with dedicated pages for sessions, metrics, runtime details, and bypass management, and add the template dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fca62c636c8325bd51ea6ab9f50729