### PR TITLE
Stack transcripts vertically on sessions page

### DIFF
--- a/app/templates/admin/sessions.html
+++ b/app/templates/admin/sessions.html
@@ -117,10 +117,14 @@
     }
 
     .transcripts-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      display: flex;
+      flex-direction: column;
       gap: 1.8rem;
       margin-top: 2rem;
+    }
+
+    .transcripts-grid > * {
+      width: 100%;
     }
 
     .transcript-card {


### PR DESCRIPTION
## Summary
- update the admin sessions template so transcript panels stack vertically
- ensure each transcript block spans the full width of its row for clearer separation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fcc7d231ec8325b2f8298db2f40b2f