### PR TITLE
Improve admin metrics chart usability

### DIFF
--- a/app/templates/admin/metrics.html
+++ b/app/templates/admin/metrics.html
@@ -8,15 +8,20 @@
       <h2>نمای زنده متریک‌های سرویس</h2>
       <p>آخرین به‌روزرسانی: <strong id="lastUpdated">—</strong></p>
     </div>
-    <div class="interval-control">
-      <label for="intervalSelect">بازهٔ به‌روزرسانی</label>
-      <select id="intervalSelect">
-        <option value="5000">۵ ثانیه</option>
-        <option value="10000">۱۰ ثانیه</option>
-        <option value="20000" selected>۲۰ ثانیه</option>
-        <option value="30000">۳۰ ثانیه</option>
-        <option value="60000">۶۰ ثانیه</option>
-      </select>
+    <div class="header-controls">
+      <div class="interval-control">
+        <label for="intervalSelect">بازهٔ به‌روزرسانی</label>
+        <select id="intervalSelect">
+          <option value="5000">۵ ثانیه</option>
+          <option value="10000">۱۰ ثانیه</option>
+          <option value="20000" selected>۲۰ ثانیه</option>
+          <option value="30000">۳۰ ثانیه</option>
+          <option value="60000">۶۰ ثانیه</option>
+        </select>
+      </div>
+      <button type="button" id="fullscreenToggle" class="zoom-button" aria-pressed="false">
+        نمایش تمام‌صفحه
+      </button>
     </div>
   </section>
 
@@ -68,6 +73,14 @@
       line-height: 1.8;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
     .interval-control {
       display: flex;
       flex-direction: column;
@@ -88,6 +101,30 @@
       font-family: inherit;
       font-size: 1rem;
       cursor: pointer;
+    }
+
+    .zoom-button {
+      padding: 0.8rem 1.4rem;
+      border-radius: 14px;
+      border: 1px solid var(--primary-dark);
+      background: linear-gradient(120deg, rgba(37, 99, 235, 0.12), rgba(37, 99, 235, 0.28));
+      color: var(--primary-dark);
+      font-family: inherit;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .zoom-button:hover,
+    .zoom-button:focus {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px rgba(37, 99, 235, 0.22);
+    }
+
+    .zoom-button[aria-pressed="true"] {
+      background: linear-gradient(120deg, rgba(37, 99, 235, 0.28), rgba(37, 99, 235, 0.45));
+      color: #0f172a;
     }
 
     .stats {
@@ -125,6 +162,12 @@
       border: 1px solid rgba(148, 163, 184, 0.25);
       padding: 1rem;
       box-shadow: inset 0 3px 18px rgba(15, 23, 42, 0.06);
+      position: relative;
+      min-height: 420px;
+    }
+
+    .chart-wrapper canvas {
+      height: 100% !important;
     }
 
     .status-message {
@@ -142,6 +185,7 @@
       const intervalSelect = document.getElementById("intervalSelect");
       const statusMessage = document.getElementById("metricsStatus");
       const ctx = document.getElementById("metricsChart");
+      const fullscreenToggle = document.getElementById("fullscreenToggle");
 
       statusMessage.hidden = true;
 
@@ -217,6 +261,21 @@
         statusMessage.hidden = !message;
       }
 
+      function toggleFullscreen() {
+        const isActive = document.fullscreenElement != null;
+        if (isActive) {
+          document.exitFullscreen().catch(() => {});
+        } else {
+          document.documentElement.requestFullscreen().catch(() => {});
+        }
+      }
+
+      function updateFullscreenState() {
+        const isActive = document.fullscreenElement != null;
+        fullscreenToggle.setAttribute("aria-pressed", String(isActive));
+        fullscreenToggle.textContent = isActive ? "خروج از تمام‌صفحه" : "نمایش تمام‌صفحه";
+      }
+
       function scheduleNext(interval) {
         if (timer) {
           clearTimeout(timer);
@@ -266,6 +325,10 @@
       intervalSelect.addEventListener("change", () => {
         fetchMetrics();
       });
+
+      fullscreenToggle.addEventListener("click", toggleFullscreen);
+      document.addEventListener("fullscreenchange", updateFullscreenState);
+      updateFullscreenState();
 
       fetchMetrics();
     });


### PR DESCRIPTION
## Summary
- enlarge the metrics dashboard chart container for improved readability
- add a fullscreen toggle control to the admin metrics view

## Testing
- pytest *(fails: requires jinja2 to be installed for templating)*

------
https://chatgpt.com/codex/tasks/task_e_68fcce92292883259f3eff82234a1863