### PR TITLE
Fix Menu Positioning in Admin Panel

### DIFF
--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -39,7 +39,7 @@
       }
 
       body.header-collapsed header.topbar {
-        justify-content: flex-end;
+        justify-content: flex-start;
         padding-inline: 1rem;
       }
 


### PR DESCRIPTION
Changed justify-content from flex-end to flex-start in RTL layout so the menu toggle button appears on the right side (natural position in Persian/RTL interface) when the header is collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)