### PR TITLE
Revamp chat client flow and expose session detail API

### DIFF
--- a/examples/chat.html
+++ b/examples/chat.html
@@ -3,172 +3,244 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>FastAPI Chat Client</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/font-face.css" />
+  <title>کلاینت گفتگو</title>
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/font-face.css"
+  />
   <style>
     :root {
-      color-scheme: light dark;
+      color-scheme: light;
       --bg: #0f172a;
-      --bg-card: rgba(15, 23, 42, 0.7);
-      --bg-input: rgba(255, 255, 255, 0.08);
+      --bg-alt: rgba(15, 23, 42, 0.78);
+      --bg-soft: rgba(15, 23, 42, 0.55);
+      --bg-input: rgba(148, 163, 184, 0.14);
       --fg: #e2e8f0;
+      --fg-muted: rgba(226, 232, 240, 0.75);
       --accent: #38bdf8;
-      --accent-soft: rgba(56, 189, 248, 0.18);
+      --accent-soft: rgba(56, 189, 248, 0.2);
+      --danger: rgba(248, 113, 113, 0.92);
       font-family: 'Vazir', 'Vazirmatn', sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
     }
 
     body {
       margin: 0;
       min-height: 100vh;
-      background: linear-gradient(135deg, #0f172a 0%, #1d4ed8 100%);
-      font-family: 'Vazir', 'Vazirmatn', sans-serif;
-      color: var(--fg);
       display: flex;
       align-items: center;
       justify-content: center;
       padding: 1.5rem;
-      box-sizing: border-box;
+      background: radial-gradient(circle at top left, #1d4ed8 0%, #0f172a 55%, #020617 100%);
+      font-family: 'Vazir', 'Vazirmatn', sans-serif;
+      color: var(--fg);
     }
 
     .app {
-      width: min(960px, 100%);
-      background: rgba(15, 23, 42, 0.78);
-      border: 1px solid rgba(148, 163, 184, 0.2);
-      border-radius: 18px;
-      box-shadow: 0 24px 80px rgba(15, 23, 42, 0.45);
-      backdrop-filter: blur(18px);
+      width: min(1080px, 100%);
       display: grid;
-      grid-template-rows: auto 1fr auto;
-      overflow: hidden;
+      gap: 1.75rem;
+      padding: clamp(1.5rem, 4vw, 2.5rem);
+      background: rgba(15, 23, 42, 0.85);
+      border-radius: 26px;
+      border: 1px solid rgba(148, 163, 184, 0.28);
+      box-shadow: 0 30px 80px rgba(15, 23, 42, 0.55);
+      backdrop-filter: blur(22px);
     }
 
-    header {
-      padding: 1.5rem;
-      border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    .brand {
+      text-align: center;
+      display: grid;
+      gap: 0.75rem;
     }
 
-    header h1 {
-      margin: 0 0 0.25rem;
-      font-size: 1.5rem;
-      font-weight: 700;
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-
-    header p {
+    .brand h1 {
       margin: 0;
+      font-size: clamp(1.6rem, 4vw, 2.1rem);
+      font-weight: 800;
+    }
+
+    .brand p {
+      margin: 0 auto;
+      max-width: 36rem;
+      line-height: 1.9;
+      color: var(--fg-muted);
+      font-size: 0.95rem;
+    }
+
+    .panels {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .hidden {
+      display: none !important;
+    }
+
+    .panel {
+      background: var(--bg-alt);
+      border-radius: 22px;
+      border: 1px solid rgba(148, 163, 184, 0.28);
+      padding: clamp(1.25rem, 3vw, 1.75rem);
+      display: grid;
+      gap: 1.25rem;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    }
+
+    .panel.hidden {
+      display: none;
+    }
+
+    .panel h2 {
+      margin: 0;
+      font-size: 1.25rem;
+      font-weight: 700;
+    }
+
+    .panel p.description {
+      margin: 0;
+      color: var(--fg-muted);
+      line-height: 1.8;
+      font-size: 0.92rem;
+    }
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.45rem;
       font-size: 0.9rem;
-      color: rgba(226, 232, 240, 0.75);
-    }
-
-    header label {
-      display: block;
-      margin-top: 0.75rem;
-      font-size: 0.9rem;
-    }
-
-    header input,
-    header select {
-      width: 100%;
-      margin-top: 0.35rem;
-      padding: 0.65rem 0.75rem;
-      border-radius: 12px;
-      border: 1px solid rgba(148, 163, 184, 0.35);
-      background: rgba(15, 23, 42, 0.55);
-      color: inherit;
-      font: inherit;
-    }
-
-    header textarea {
-      width: 100%;
-      margin-top: 0.5rem;
-      padding: 0.75rem;
-      border-radius: 12px;
-      border: 1px solid rgba(148, 163, 184, 0.35);
-      background: rgba(15, 23, 42, 0.55);
-      color: inherit;
-      font: inherit;
-      min-height: 90px;
-      resize: vertical;
-    }
-
-    header button {
-      margin-top: 0.9rem;
-      padding: 0.65rem 1rem;
-      border-radius: 12px;
-      border: none;
-      background: var(--accent);
-      color: #0f172a;
-      font: inherit;
-      font-weight: 600;
-      cursor: pointer;
-      transition: transform 0.15s ease, box-shadow 0.2s ease;
-    }
-
-    header button:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 12px 30px rgba(56, 189, 248, 0.35);
-    }
-
-    header details {
-      margin-top: 0.9rem;
-      border-radius: 14px;
-      border: 1px solid rgba(148, 163, 184, 0.25);
-      background: rgba(15, 23, 42, 0.55);
-      padding: 0.75rem 1rem;
-    }
-
-    header details summary {
-      cursor: pointer;
-      font-weight: 600;
       color: rgba(226, 232, 240, 0.9);
     }
 
-    header details[open] summary {
-      margin-bottom: 0.5rem;
+    input,
+    textarea,
+    button {
+      font: inherit;
     }
 
-    main {
-      padding: 1.25rem;
+    input,
+    textarea {
+      width: 100%;
+      padding: 0.75rem 0.85rem;
+      border-radius: 14px;
+      border: 1px solid rgba(148, 163, 184, 0.32);
+      background: var(--bg-soft);
+      color: inherit;
+      transition: border 0.15s ease, box-shadow 0.2s ease;
+    }
+
+    input:focus,
+    textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--accent-soft);
+    }
+
+    .form-grid {
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .form-grid.two-column {
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 0.85rem;
+    }
+
+    button {
+      border: none;
+      border-radius: 14px;
+      padding: 0.8rem 1.4rem;
+      cursor: pointer;
+      font-weight: 700;
+      background: var(--accent);
+      color: #0f172a;
+      transition: transform 0.15s ease, box-shadow 0.2s ease;
+    }
+
+    button:hover:not(:disabled) {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 35px rgba(56, 189, 248, 0.32);
+    }
+
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.7;
+      box-shadow: none;
+    }
+
+    button.secondary {
+      background: var(--danger);
+      color: #0f172a;
+    }
+
+    .status {
+      margin: 0;
+      font-size: 0.85rem;
+      color: var(--fg-muted);
+      line-height: 1.7;
+    }
+
+    .chat-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .chat-header h2 {
+      margin: 0;
+    }
+
+    .chat-body {
+      min-height: clamp(260px, 45vh, 420px);
+      max-height: 520px;
       overflow-y: auto;
       display: flex;
       flex-direction: column;
       gap: 0.75rem;
-      background: rgba(15, 23, 42, 0.35);
+      padding: 1rem;
+      border-radius: 18px;
+      background: rgba(15, 23, 42, 0.55);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+    }
+
+    .empty-state {
+      margin: 0;
+      text-align: center;
+      color: var(--fg-muted);
+      font-size: 0.9rem;
+      padding: 2rem 0;
     }
 
     .message {
       display: grid;
-      gap: 0.5rem;
-      padding: 0.95rem 1rem;
+      gap: 0.55rem;
+      padding: 0.9rem 1rem;
       border-radius: 16px;
-      background: rgba(148, 163, 184, 0.12);
-      border: 1px solid rgba(148, 163, 184, 0.18);
+      background: rgba(148, 163, 184, 0.15);
+      border: 1px solid rgba(148, 163, 184, 0.2);
       position: relative;
-      backdrop-filter: blur(6px);
+      backdrop-filter: blur(8px);
     }
 
     .message.user {
       margin-left: auto;
-      background: rgba(56, 189, 248, 0.12);
-      border-color: rgba(56, 189, 248, 0.25);
+      background: rgba(56, 189, 248, 0.16);
+      border-color: rgba(56, 189, 248, 0.28);
     }
 
     .message .meta {
-      font-size: 0.8rem;
-      color: rgba(226, 232, 240, 0.7);
       display: flex;
+      align-items: center;
       justify-content: space-between;
-      align-items: center;
       gap: 0.75rem;
+      font-size: 0.78rem;
+      color: rgba(226, 232, 240, 0.75);
       flex-wrap: wrap;
-    }
-
-    .message .meta .group {
-      display: inline-flex;
-      gap: 0.35rem;
-      align-items: center;
     }
 
     .message .body {
@@ -179,199 +251,116 @@
     }
 
     .message .metadata {
-      font-size: 0.75rem;
-      line-height: 1.6;
-      padding: 0.6rem 0.75rem;
-      background: rgba(15, 23, 42, 0.45);
-      border-radius: 12px;
-      border: 1px solid rgba(148, 163, 184, 0.2);
+      font-size: 0.78rem;
       direction: ltr;
       text-align: left;
-    }
-
-    footer {
-      padding: 1.25rem;
-      border-top: 1px solid rgba(148, 163, 184, 0.2);
-      background: rgba(15, 23, 42, 0.6);
-    }
-
-    form {
-      display: flex;
-      gap: 0.75rem;
-      align-items: flex-end;
-    }
-
-    textarea {
-      flex: 1;
-      min-height: 68px;
-      max-height: 200px;
-      resize: vertical;
-      padding: 0.75rem;
-      border-radius: 16px;
-      border: 1px solid rgba(148, 163, 184, 0.35);
-      background: rgba(15, 23, 42, 0.55);
-      color: inherit;
-      font: inherit;
-      line-height: 1.6;
-    }
-
-    footer button {
-      padding: 0.8rem 1.6rem;
-      border-radius: 16px;
-      border: none;
-      background: var(--accent);
-      color: #0f172a;
-      font: inherit;
-      font-weight: 700;
-      cursor: pointer;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      transition: transform 0.15s ease, box-shadow 0.2s ease;
-    }
-
-    footer button:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 12px 28px rgba(56, 189, 248, 0.3);
-    }
-
-    footer details {
-      margin-top: 1rem;
-      border-radius: 14px;
-      border: 1px solid rgba(148, 163, 184, 0.25);
-      background: rgba(15, 23, 42, 0.5);
-      padding: 0.75rem 1rem;
-    }
-
-    footer details summary {
-      cursor: pointer;
-      font-weight: 600;
-      color: rgba(226, 232, 240, 0.9);
-    }
-
-    footer details[open] summary {
-      margin-bottom: 0.5rem;
-    }
-
-    footer details label {
-      display: block;
-      margin-top: 0.65rem;
-      font-size: 0.85rem;
-    }
-
-    footer details input,
-    footer details textarea {
-      width: 100%;
-      margin-top: 0.35rem;
       padding: 0.6rem 0.75rem;
       border-radius: 12px;
-      border: 1px solid rgba(148, 163, 184, 0.35);
-      background: rgba(15, 23, 42, 0.55);
-      color: inherit;
-      font: inherit;
+      background: rgba(15, 23, 42, 0.6);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .composer {
+      display: flex;
+      align-items: flex-end;
+      gap: 0.75rem;
+    }
+
+    .composer textarea {
       resize: vertical;
-      min-height: 60px;
+      min-height: 68px;
+      max-height: 200px;
     }
 
-    .status {
-      font-size: 0.85rem;
-      color: rgba(226, 232, 240, 0.8);
-      margin-top: 0.75rem;
-    }
+    @media (max-width: 840px) {
+      .app {
+        padding: 1.25rem;
+      }
 
-    .status.note {
-      margin-top: 0.5rem;
-      color: rgba(226, 232, 240, 0.65);
-    }
+      .chat-header {
+        flex-direction: column;
+        align-items: stretch;
+      }
 
-    .status strong {
-      color: var(--accent);
-    }
-
-    .hidden {
-      display: none;
-    }
-
-    code.inline {
-      background: rgba(148, 163, 184, 0.2);
-      padding: 0.1rem 0.4rem;
-      border-radius: 8px;
-      direction: ltr;
+      button.secondary {
+        align-self: stretch;
+      }
     }
   </style>
 </head>
 <body>
   <div class="app">
-    <header>
-      <h1>کلاینت چت FastAPI</h1>
-      <p>برای شروع آدرس سرویس را وارد کن تا سشن جدید ساخته شود.</p>
-      <label>
-        آدرس سرور (مثلاً <code class="inline">http://localhost:8000</code>)
-        <input
-          id="baseUrl"
-          type="url"
-          placeholder="http://localhost:8000"
-          value="http://localhost:8000"
-        />
-      </label>
-      <details>
-        <summary>تنظیمات پیشرفته سشن</summary>
-        <label>
-          نام و نام خانوادگی (اختیاری)
-          <input id="userName" type="text" placeholder="نام کامل خود را وارد کنید" />
-        </label>
-        <label>
-          شماره موبایل (اختیاری)
-          <input id="userMobile" type="tel" placeholder="09123456789" />
-        </label>
-        <label>
-          ایمیل (اختیاری)
-          <input id="userEmail" type="email" placeholder="example@email.com" />
-        </label>
-        <label>
-          سقف حافظه‌ی سشن (تعداد پیام)
-          <input id="memoryLimit" type="number" min="1" placeholder="مثلاً 20" />
-        </label>
-        <label>
-          متادیتای اضافی (JSON اختیاری)
-          <textarea id="metadata" placeholder='{"topic":"demo"}'></textarea>
-        </label>
-      </details>
-      <button id="createSession">ساخت سشن جدید</button>
-      <p class="status" id="sessionStatus">سشنی ساخته نشده است.</p>
-      <p class="status note">
-        این کلاینت همیشه از سرویس <strong>OpenRouter</strong> با تنظیماتی که در متغیرهای محیطی برنامه (مانند
-        <code class="inline">DEFAULT_PROVIDER</code> و <code class="inline">OPENROUTER_KEY</code>) مشخص می‌کنی استفاده می‌کند.
-      </p>
-      <button id="deleteSession" class="hidden" style="background: rgba(248, 113, 113, 0.9); color: #0f172a;">حذف سشن</button>
-    </header>
-    <main id="messages"></main>
-    <footer>
-      <form id="chatForm">
-        <textarea id="messageInput" placeholder="پیامت را اینجا بنویس..." disabled></textarea>
-        <button type="submit" id="sendBtn" disabled>ارسال</button>
-      </form>
-      <details class="message-options">
-        <summary>تنظیمات پیام</summary>
-        <label>
-          سقف حافظه فقط برای این پیام
-          <input id="messageMemory" type="number" min="1" placeholder="مثلاً 5" />
-        </label>
-        <label>
-          آپشن‌های اضافه (JSON)
-          <textarea id="messageOptions" placeholder='{"temperature":0.7}'></textarea>
-        </label>
-      </details>
-      <p class="status" id="requestStatus"></p>
-    </footer>
+    <div class="brand">
+      <h1>دستیار گفتگوی FastAPI</h1>
+      <p>با وارد کردن اطلاعات تماس، سشن اختصاصی تو ساخته می‌شود و می‌توانی گفتگوی قبلی را ادامه بدهی یا گفتگوی تازه‌ای را شروع کنی.</p>
+    </div>
+
+    <div class="panels">
+      <section class="panel session" id="sessionPanel">
+        <div>
+          <h2>شروع گفتگو</h2>
+          <p class="description">اطلاعات زیر فقط برای ثبت در متادیتای سشن استفاده می‌شود.</p>
+        </div>
+        <form id="sessionForm">
+          <div class="form-grid">
+            <label>
+              آدرس سرویس
+              <input
+                id="baseUrl"
+                type="url"
+                placeholder="http://localhost:8000"
+                value="http://localhost:8000"
+                required
+              />
+            </label>
+            <div class="form-grid two-column">
+              <label>
+                نام
+                <input id="firstName" type="text" placeholder="نام" />
+              </label>
+              <label>
+                نام خانوادگی
+                <input id="lastName" type="text" placeholder="نام خانوادگی" />
+              </label>
+            </div>
+            <div class="form-grid two-column">
+              <label>
+                ایمیل
+                <input id="email" type="email" placeholder="example@email.com" />
+              </label>
+              <label>
+                شماره موبایل
+                <input id="mobile" type="tel" placeholder="09123456789" />
+              </label>
+            </div>
+          </div>
+          <button type="submit" id="startChat">شروع گفتگو</button>
+        </form>
+        <p class="status" id="formStatus">برای شروع گفتگو فرم را تکمیل کن.</p>
+      </section>
+
+      <section class="panel chat hidden" id="chatPanel">
+        <div class="chat-header">
+          <div>
+            <h2>گفتگوی فعال</h2>
+            <p class="status" id="sessionInfo"></p>
+          </div>
+          <button type="button" id="deleteConversation" class="secondary hidden">حذف گفتگو</button>
+        </div>
+        <div id="messages" class="chat-body"></div>
+        <form id="chatForm" class="composer">
+          <textarea id="messageInput" placeholder="پیامت را اینجا بنویس..." disabled></textarea>
+          <button type="submit" id="sendBtn" disabled>ارسال</button>
+        </form>
+        <p class="status" id="requestStatus"></p>
+      </section>
+    </div>
   </div>
 
   <template id="messageTemplate">
     <div class="message">
       <div class="meta">
-        <span class="group">
-          <span class="role"></span>
-        </span>
+        <span class="role"></span>
         <span class="timestamp"></span>
       </div>
       <div class="body"></div>
@@ -380,25 +369,33 @@
   </template>
 
   <script>
+    const LOCAL_STORAGE_KEY = 'fastapi-chat-session';
     const baseUrlInput = document.getElementById('baseUrl');
-    const userNameInput = document.getElementById('userName');
-    const userMobileInput = document.getElementById('userMobile');
-    const userEmailInput = document.getElementById('userEmail');
-    const memoryLimitInput = document.getElementById('memoryLimit');
-    const metadataInput = document.getElementById('metadata');
-    const createSessionBtn = document.getElementById('createSession');
-    const deleteSessionBtn = document.getElementById('deleteSession');
-    const sessionStatus = document.getElementById('sessionStatus');
+    const firstNameInput = document.getElementById('firstName');
+    const lastNameInput = document.getElementById('lastName');
+    const emailInput = document.getElementById('email');
+    const mobileInput = document.getElementById('mobile');
+    const sessionForm = document.getElementById('sessionForm');
+    const sessionPanel = document.getElementById('sessionPanel');
+    const chatPanel = document.getElementById('chatPanel');
+    const startChatBtn = document.getElementById('startChat');
+    const deleteConversationBtn = document.getElementById('deleteConversation');
+    const formStatus = document.getElementById('formStatus');
+    const sessionInfo = document.getElementById('sessionInfo');
     const requestStatus = document.getElementById('requestStatus');
-    const messagesEl = document.getElementById('messages');
     const chatForm = document.getElementById('chatForm');
     const messageInput = document.getElementById('messageInput');
     const sendBtn = document.getElementById('sendBtn');
+    const messagesEl = document.getElementById('messages');
     const messageTemplate = document.getElementById('messageTemplate');
-    const messageMemoryInput = document.getElementById('messageMemory');
-    const messageOptionsInput = document.getElementById('messageOptions');
 
-    let sessionId = null;
+    let sessionState = {
+      id: null,
+      baseUrl: '',
+      metadata: {},
+      history: []
+    };
+
     const formatDateTime = (value) => {
       const date = value instanceof Date ? value : new Date(value);
       return new Intl.DateTimeFormat('fa-IR', {
@@ -408,37 +405,14 @@
       }).format(date);
     };
 
-    const parseJsonField = (value, label) => {
-      if (!value.trim()) {
-        return {};
-      }
-      try {
-        const parsed = JSON.parse(value);
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-          return parsed;
-        }
-      } catch (error) {
-        // handled below
-      }
-      throw new Error(`${label} باید JSON معتبر از نوع آبجکت باشد.`);
-    };
-
-    const parseOptionalNumber = (value, label) => {
-      const trimmed = value.trim();
-      if (!trimmed) return undefined;
-      const number = Number(trimmed);
-      if (!Number.isFinite(number) || number < 1) {
-        throw new Error(`${label} باید یک عدد بزرگ‌تر از صفر باشد.`);
-      }
-      return number;
-    };
-
     const extractErrorMessage = (payload) => {
-      if (!payload) return 'خطای ناشناخته از سمت سرور.';
+      if (!payload) return 'پاسخ نامعتبر از سمت سرور.';
       if (typeof payload === 'string') return payload;
       if (payload.error) {
         if (typeof payload.error === 'string') return payload.error;
-        if (typeof payload.error.message === 'string') return payload.error.message;
+        if (payload.error && typeof payload.error.message === 'string') {
+          return payload.error.message;
+        }
       }
       if (payload.detail) {
         if (typeof payload.detail === 'string') return payload.detail;
@@ -446,14 +420,79 @@
           return payload.detail.map((item) => item.msg).join('، ');
         }
       }
-      return JSON.stringify(payload, null, 2);
+      if (typeof payload.message === 'string') {
+        return payload.message;
+      }
+      try {
+        return JSON.stringify(payload, null, 2);
+      } catch (error) {
+        return 'خطای ناشناخته.';
+      }
     };
 
-    function appendMessage({ role, content, timestamp = new Date(), metadata = null }) {
+    const loadStoredSession = () => {
+      try {
+        const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+        return raw ? JSON.parse(raw) : null;
+      } catch (error) {
+        return null;
+      }
+    };
+
+    const persistSession = () => {
+      if (!sessionState.id) {
+        localStorage.removeItem(LOCAL_STORAGE_KEY);
+        return;
+      }
+      const payload = {
+        id: sessionState.id,
+        baseUrl: sessionState.baseUrl,
+        metadata: sessionState.metadata,
+        history: sessionState.history
+      };
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(payload));
+    };
+
+    const resetSessionState = (baseUrl = '') => {
+      sessionState = { id: null, baseUrl, metadata: {}, history: [] };
+      updateSessionInfo();
+    };
+
+    const togglePanels = (sessionActive) => {
+      sessionPanel.classList.toggle('hidden', sessionActive);
+      chatPanel.classList.toggle('hidden', !sessionActive);
+    };
+
+    const updateSessionInfo = () => {
+      if (!sessionState.id) {
+        sessionInfo.textContent = '';
+        return;
+      }
+      const infoParts = [];
+      const metadata = sessionState.metadata || {};
+      if (metadata.full_name) infoParts.push(`نام: ${metadata.full_name}`);
+      if (!metadata.full_name) {
+        if (metadata.first_name) infoParts.push(`نام: ${metadata.first_name}`);
+        if (metadata.last_name) infoParts.push(`نام خانوادگی: ${metadata.last_name}`);
+      }
+      if (metadata.email) infoParts.push(`ایمیل: ${metadata.email}`);
+      if (metadata.mobile) infoParts.push(`موبایل: ${metadata.mobile}`);
+      sessionInfo.textContent = [`شناسه سشن: ${sessionState.id}`, ...infoParts].join(' | ');
+    };
+
+    const clearMessages = () => {
+      messagesEl.innerHTML = '';
+    };
+
+    const appendMessage = ({ role, content, timestamp = new Date(), metadata = null }) => {
+      if (messagesEl.firstElementChild && messagesEl.firstElementChild.classList.contains('empty-state')) {
+        messagesEl.innerHTML = '';
+      }
       const node = messageTemplate.content.firstElementChild.cloneNode(true);
       node.classList.toggle('user', role === 'user');
       node.dataset.role = role;
-      node.querySelector('.role').textContent = role === 'assistant' ? 'دستیار' : role === 'system' ? 'سیستم' : 'کاربر';
+      node.querySelector('.role').textContent =
+        role === 'assistant' ? 'دستیار' : role === 'system' ? 'سیستم' : 'کاربر';
       node.querySelector('.timestamp').textContent = formatDateTime(timestamp);
       node.querySelector('.body').textContent = content;
 
@@ -467,194 +506,251 @@
 
       messagesEl.appendChild(node);
       messagesEl.scrollTop = messagesEl.scrollHeight;
-    }
+    };
 
-    function clearMessages() {
-      messagesEl.innerHTML = '';
-    }
-
-    function setLoading(loading, message = '') {
-      if (loading) {
-        requestStatus.innerHTML = `در حال پردازش... <strong>${message}</strong>`;
-        sendBtn.disabled = true;
-        createSessionBtn.disabled = true;
-      } else {
-        requestStatus.textContent = message;
-        sendBtn.disabled = !sessionId;
-        createSessionBtn.disabled = false;
+    const renderMessages = (history) => {
+      clearMessages();
+      if (!history || history.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'empty-state';
+        empty.textContent = 'هنوز پیامی ثبت نشده است.';
+        messagesEl.appendChild(empty);
+        return;
       }
-    }
+      history.forEach((message) =>
+        appendMessage({
+          role: message.role,
+          content: message.content,
+          timestamp: message.created_at,
+          metadata: message.metadata || null
+        })
+      );
+    };
 
-    async function createSession() {
+    const setFormBusy = (loading, message) => {
+      startChatBtn.disabled = loading;
+      sessionForm.classList.toggle('loading', loading);
+      if (typeof message === 'string') {
+        formStatus.textContent = message;
+      }
+    };
+
+    const setChatBusy = (loading, message) => {
+      if (typeof message === 'string') {
+        requestStatus.textContent = message;
+      }
+      const disabled = loading || !sessionState.id;
+      messageInput.disabled = disabled;
+      deleteConversationBtn.disabled = disabled;
+      if (loading) {
+        sendBtn.disabled = true;
+      } else {
+        sendBtn.disabled = !sessionState.id || !messageInput.value.trim();
+        if (sessionState.id) {
+          messageInput.focus();
+        }
+      }
+    };
+
+    const buildSessionMetadata = () => {
+      const metadata = {};
+      const firstName = firstNameInput.value.trim();
+      const lastName = lastNameInput.value.trim();
+      const email = emailInput.value.trim();
+      const mobile = mobileInput.value.trim();
+
+      if (firstName) metadata.first_name = firstName;
+      if (lastName) metadata.last_name = lastName;
+      const fullName = [firstName, lastName].filter(Boolean).join(' ');
+      if (fullName) metadata.full_name = fullName;
+      if (email) metadata.email = email;
+      if (mobile) metadata.mobile = mobile;
+      return metadata;
+    };
+
+    const fillFormFromMetadata = (metadata) => {
+      if (!metadata) return;
+      if (metadata.baseUrl) {
+        baseUrlInput.value = metadata.baseUrl;
+      }
+      if (metadata.first_name) firstNameInput.value = metadata.first_name;
+      if (metadata.last_name) lastNameInput.value = metadata.last_name;
+      if (metadata.full_name && !metadata.first_name && !metadata.last_name) {
+        const [first, ...rest] = metadata.full_name.split(' ');
+        firstNameInput.value = first || '';
+        lastNameInput.value = rest.join(' ');
+      }
+      if (metadata.email) emailInput.value = metadata.email;
+      if (metadata.mobile) mobileInput.value = metadata.mobile;
+    };
+
+    const loadSessionFromServer = async (sessionId, baseUrl, metadataOverrides = {}) => {
+      const url = new URL(`/sessions/${sessionId}`, baseUrl);
+      const response = await fetch(url);
+      let data = null;
+      try {
+        data = await response.json();
+      } catch (error) {
+        /* ignore non JSON responses */
+      }
+      if (!response.ok) {
+        throw new Error(extractErrorMessage(data));
+      }
+      const history = Array.isArray(data.history) ? data.history : [];
+      sessionState = {
+        id: data.id,
+        baseUrl,
+        metadata: { ...(data.metadata || {}), ...(metadataOverrides || {}) },
+        history
+      };
+      persistSession();
+      togglePanels(true);
+      updateSessionInfo();
+      renderMessages(history);
+      deleteConversationBtn.classList.remove('hidden');
+      setChatBusy(false, history.length ? 'سشن آماده ادامه گفتگو است.' : 'سشن تازه آماده شد.');
+    };
+
+    const restoreFromStorage = async () => {
+      const saved = loadStoredSession();
+      if (!saved) {
+        togglePanels(false);
+        return;
+      }
+      if (saved.baseUrl) {
+        baseUrlInput.value = saved.baseUrl;
+      }
+      fillFormFromMetadata(saved.metadata || {});
+      try {
+        setFormBusy(true, 'در حال بررسی سشن ذخیره شده...');
+        await loadSessionFromServer(saved.id, saved.baseUrl, saved.metadata || {});
+        setFormBusy(false, '');
+      } catch (error) {
+        resetSessionState(saved.baseUrl || '');
+        persistSession();
+        setFormBusy(false, error.message || 'سشن ذخیره شده معتبر نیست.');
+        togglePanels(false);
+        requestStatus.textContent = '';
+      }
+    };
+
+    const createSession = async () => {
       const baseUrl = baseUrlInput.value.trim();
       if (!baseUrl) {
-        alert('آدرس سرور را وارد کن.');
+        formStatus.textContent = 'آدرس سرویس را وارد کن.';
         return;
       }
-
-      let metadata;
-      let memoryLimit;
+      const metadata = buildSessionMetadata();
+      setFormBusy(true, 'در حال ساخت سشن جدید...');
       try {
-        metadata = parseJsonField(metadataInput.value, 'متادیتا');
-        memoryLimit = parseOptionalNumber(memoryLimitInput.value, 'سقف حافظه سشن');
-      } catch (error) {
-        alert(error.message);
-        return;
-      }
-
-      // اضافه کردن فیلدهای کاربر به metadata
-      const userName = userNameInput.value.trim();
-      const userMobile = userMobileInput.value.trim();
-      const userEmail = userEmailInput.value.trim();
-
-      if (userName) {
-        metadata.name = userName;
-      }
-      if (userMobile) {
-        metadata.mobile = userMobile;
-      }
-      if (userEmail) {
-        metadata.email = userEmail;
-      }
-
-      setLoading(true, 'در حال ساخت سشن جدید');
-      try {
-        const payload = {
-          memory_limit: memoryLimit,
-          metadata: Object.keys(metadata).length ? metadata : undefined
-        };
         const response = await fetch(new URL('/sessions', baseUrl), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
+          body: JSON.stringify({ metadata })
         });
-
-        let data = null;
-        try {
-          data = await response.json();
-        } catch (error) {
-          /* ignore non JSON */
-        }
-
-        if (!response.ok) {
-          throw new Error(extractErrorMessage(data));
-        }
-
-        sessionId = data.id;
-        sessionStatus.innerHTML = `سشن فعال: <strong>${sessionId}</strong>`;
-        deleteSessionBtn.classList.remove('hidden');
-        messageInput.disabled = false;
-        sendBtn.disabled = false;
-        clearMessages();
-        appendMessage({
-          role: 'assistant',
-          content: 'سشن با موفقیت ساخته شد! حالا پیام خود را ارسال کن.',
-          metadata: Object.keys(data.metadata || {}).length ? data.metadata : null
-        });
-        requestStatus.textContent = '';
-      } catch (error) {
-        console.error(error);
-        requestStatus.textContent = 'ساخت سشن با خطا مواجه شد.';
-        sessionStatus.textContent = error.message || 'سشنی ساخته نشده است.';
-        sessionId = null;
-        deleteSessionBtn.classList.add('hidden');
-        messageInput.disabled = true;
-        sendBtn.disabled = true;
-      } finally {
-        setLoading(false, sessionId ? 'سشن آماده است.' : '');
-      }
-    }
-
-    async function deleteSession() {
-      if (!sessionId) return;
-      const baseUrl = baseUrlInput.value.trim();
-      try {
-        await fetch(new URL(`/sessions/${sessionId}`, baseUrl), {
-          method: 'DELETE'
-        });
-      } catch (error) {
-        console.warn('حذف سشن با خطا مواجه شد', error);
-      }
-      sessionId = null;
-      sessionStatus.textContent = 'سشنی ساخته نشده است.';
-      messageInput.disabled = true;
-      sendBtn.disabled = true;
-      deleteSessionBtn.classList.add('hidden');
-      appendMessage({
-        role: 'assistant',
-        content: 'سشن بسته شد.'
-      });
-      requestStatus.textContent = '';
-    }
-
-    async function sendMessage(content) {
-      if (!sessionId) {
-        alert('ابتدا سشن بساز.');
-        return;
-      }
-      const baseUrl = baseUrlInput.value.trim();
-
-      let messageMemoryLimit;
-      let messageOptions;
-      try {
-        messageMemoryLimit = parseOptionalNumber(messageMemoryInput.value, 'سقف حافظه پیام');
-        messageOptions = parseJsonField(messageOptionsInput.value, 'آپشن‌های پیام');
-      } catch (error) {
-        alert(error.message);
-        return;
-      }
-
-      appendMessage({ role: 'user', content, timestamp: new Date() });
-      setLoading(true, 'در انتظار پاسخ سرور');
-
-      try {
-        const payload = {
-          content,
-          memory_limit: messageMemoryLimit,
-          options: Object.keys(messageOptions).length ? messageOptions : undefined
-        };
-
-        const response = await fetch(new URL(`/sessions/${sessionId}/messages`, baseUrl), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        });
-
         let data = null;
         try {
           data = await response.json();
         } catch (error) {
           /* ignore */
         }
-
         if (!response.ok) {
-          const message = extractErrorMessage(data);
-          throw new Error(message);
+          throw new Error(extractErrorMessage(data));
         }
-
-        appendMessage({
-          role: data.message.role,
-          content: data.message.content,
-          timestamp: data.message.created_at,
-          metadata: data.message.metadata || null
-        });
-        setLoading(false, 'پاسخ دریافت شد.');
+        if (!data || !data.id) {
+          throw new Error('پاسخ نامعتبر از سرور دریافت شد.');
+        }
+        await loadSessionFromServer(data.id, baseUrl, metadata);
+        formStatus.textContent = '';
       } catch (error) {
-        console.error(error);
-        setLoading(false, 'خطا در ارسال پیام.');
+        formStatus.textContent = error.message || 'ساخت سشن موفق نبود.';
+        resetSessionState(baseUrl);
+        persistSession();
+      } finally {
+        setFormBusy(false);
+      }
+    };
+
+    const deleteSession = async () => {
+      if (!sessionState.id) {
+        return;
+      }
+      const baseUrl = sessionState.baseUrl || baseUrlInput.value.trim();
+      setChatBusy(true, 'در حال حذف گفتگو...');
+      try {
+        const response = await fetch(new URL(`/sessions/${sessionState.id}`, baseUrl), {
+          method: 'DELETE'
+        });
+        if (!response.ok) {
+          let data = null;
+          try {
+            data = await response.json();
+          } catch (error) {
+            /* ignore */
+          }
+          throw new Error(extractErrorMessage(data));
+        }
+      } catch (error) {
+        setChatBusy(false, error.message || 'حذف گفتگو با خطا مواجه شد.');
+        return;
+      }
+      resetSessionState(baseUrl);
+      persistSession();
+      clearMessages();
+      renderMessages([]);
+      messageInput.value = '';
+      sendBtn.disabled = true;
+      deleteConversationBtn.classList.add('hidden');
+      togglePanels(false);
+      setChatBusy(false, '');
+      formStatus.textContent = 'گفتگو حذف شد. برای شروع دوباره فرم را تکمیل کن.';
+    };
+
+    const sendMessage = async (content) => {
+      if (!sessionState.id) {
+        return;
+      }
+      const baseUrl = sessionState.baseUrl || baseUrlInput.value.trim();
+      const previousHistory = sessionState.history.slice();
+      appendMessage({ role: 'user', content, timestamp: new Date() });
+      setChatBusy(true, 'در انتظار پاسخ سرور...');
+      try {
+        const response = await fetch(new URL(`/sessions/${sessionState.id}/messages`, baseUrl), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content })
+        });
+        let data = null;
+        try {
+          data = await response.json();
+        } catch (error) {
+          /* ignore */
+        }
+        if (!response.ok) {
+          throw new Error(extractErrorMessage(data));
+        }
+        const history = Array.isArray(data.history) ? data.history : [];
+        sessionState.history = history;
+        renderMessages(history);
+        persistSession();
+        setChatBusy(false, 'پاسخ دریافت شد.');
+      } catch (error) {
+        sessionState.history = previousHistory;
+        renderMessages(previousHistory);
         appendMessage({
           role: 'assistant',
-          content: error.message || 'خطای ناشناخته'
+          content: error.message || 'ارسال پیام با خطا مواجه شد.'
         });
+        setChatBusy(false, 'ارسال پیام با خطا مواجه شد.');
       }
-    }
+    };
 
-    createSessionBtn.addEventListener('click', (event) => {
+    sessionForm.addEventListener('submit', (event) => {
       event.preventDefault();
       createSession();
     });
 
-    deleteSessionBtn.addEventListener('click', (event) => {
+    deleteConversationBtn.addEventListener('click', (event) => {
       event.preventDefault();
       deleteSession();
     });
@@ -662,8 +758,11 @@
     chatForm.addEventListener('submit', (event) => {
       event.preventDefault();
       const value = messageInput.value.trim();
-      if (!value) return;
+      if (!value) {
+        return;
+      }
       messageInput.value = '';
+      sendBtn.disabled = true;
       sendMessage(value);
     });
 
@@ -673,6 +772,21 @@
         chatForm.dispatchEvent(new Event('submit'));
       }
     });
+
+    messageInput.addEventListener('input', () => {
+      if (!sessionState.id) {
+        sendBtn.disabled = true;
+        return;
+      }
+      sendBtn.disabled = !messageInput.value.trim();
+    });
+
+    (async () => {
+      renderMessages([]);
+      togglePanels(false);
+      setChatBusy(false, '');
+      await restoreFromStorage();
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a session detail response model and GET /sessions/{session_id} endpoint that returns metadata and buffered history
- redesign examples/chat.html to restore saved sessions, simplify the start form, and modernize the layout
- cover the new endpoint with an API test alongside the existing session suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fde1a909b483258210d929d786f108